### PR TITLE
Fix GitHub Actions permissions for create-pull-request

### DIFF
--- a/.github/workflows/pre-commit-update.yaml
+++ b/.github/workflows/pre-commit-update.yaml
@@ -21,6 +21,7 @@ jobs:
       - run: pre-commit autoupdate
       - uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.PAT }}
           branch: update/pre-commit-autoupdate
           title: Auto-update pre-commit hooks
           commit-message: Auto-update pre-commit hooks


### PR DESCRIPTION
Add PAT token parameter to peter-evans/create-pull-request action to resolve permission issues when creating pull requests. The default GITHUB_TOKEN has restrictions that prevent PR creation in certain scenarios.

https://claude.ai/code/session_01PAK1eULhuFa64c9DEg8WyX