### PR TITLE
Update work3 quota documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,7 +162,7 @@ source .venv/bin/activate
 | `TERM_RUNLIMIT` | Increase `-W` walltime (default is 15 min!) |
 | `TERM_CWD_NOTEXIST` | `mkdir -p logs` before submitting |
 | Job stuck in PEND | `bjobs -l <jobid>` for reasons; try different queue |
-| **Exit code 120, no traceback** | **`/work3` NVME pool quota hit (350 GB hard limit). Run `getquota_work3.sh` — check storagepool 6. Clean `wandb/cache/` and old checkpoint dirs. Every training config MUST have `keep_last_n_checkpoints: 2` + `keep_best_n_checkpoints: 1`.** |
+| **Exit code 120, no traceback** | **`/work3` NVME pool quota hit (200 GB hard limit). Run `getquota_work3.sh` — check storagepool 6. Clean `wandb/cache/` and old checkpoint dirs. Every training config MUST have `keep_last_n_checkpoints: 2` + `keep_best_n_checkpoints: 1`.** |
 
 ### Interactive GPU session
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,7 +162,7 @@ source .venv/bin/activate
 | `TERM_RUNLIMIT` | Increase `-W` walltime (default is 15 min!) |
 | `TERM_CWD_NOTEXIST` | `mkdir -p logs` before submitting |
 | Job stuck in PEND | `bjobs -l <jobid>` for reasons; try different queue |
-| **Exit code 120, no traceback** | **`/work3` NVME pool quota hit (200 GB hard limit). Run `getquota_work3.sh` — check storagepool 6. Clean `wandb/cache/` and old checkpoint dirs. Every training config MUST have `keep_last_n_checkpoints: 2` + `keep_best_n_checkpoints: 1`.** |
+| **Exit code 120, no traceback** | **`/work3` NVME pool quota hit (350 GB hard limit). Run `getquota_work3.sh` — check storagepool 6. Clean `wandb/cache/` and old checkpoint dirs. Every training config MUST have `keep_last_n_checkpoints: 2` + `keep_best_n_checkpoints: 1`.** |
 
 ### Interactive GPU session
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ source .venv/bin/activate
 | `TERM_RUNLIMIT` | Increase `-W` walltime (default is 15 min!) |
 | `TERM_CWD_NOTEXIST` | `mkdir -p logs` before submitting |
 | Job stuck in PEND | `bjobs -l <jobid>` for reasons; try different queue |
-| **Exit code 120, no traceback** | **`/work3` NVME pool quota hit (200 GB hard limit). Run `getquota_work3.sh` — check storagepool 6. Clean `wandb/cache/` and old checkpoint dirs. Every training config MUST have `keep_last_n_checkpoints: 2` + `keep_best_n_checkpoints: 1`.** |
+| **Exit code 120, no traceback** | **`/work3` NVME pool quota hit (350 GB hard limit). Run `getquota_work3.sh` — check storagepool 6. Clean `wandb/cache/` and old checkpoint dirs. Every training config MUST have `keep_last_n_checkpoints: 2` + `keep_best_n_checkpoints: 1`.** |
 
 ### Interactive GPU session
 

--- a/configs/fairseq2/3b/ctc-finetune-hpc-e6-3b-50k.yaml
+++ b/configs/fairseq2/3b/ctc-finetune-hpc-e6-3b-50k.yaml
@@ -1,0 +1,69 @@
+# Resume the completed E6-style 3B run from 30k to 50k total steps.
+#
+# IMPORTANT:
+# - This config is for resume-in-place from the original fairseq2 workspace
+#   directory (the resolved `ws_1.<hash>` path), not the parent run directory.
+# - `common.no_sweep_dir: true` disables fairseq2's automatic `ws_*` subdir
+#   creation so the exact `--output-dir` passed by the HPC wrapper is reused.
+# - fairseq2 can then restore the full training state from
+#   `<output-dir>/checkpoints/step_30000/`.
+
+common:
+  no_sweep_dir: true
+
+model:
+  name: "omniASR_CTC_3B_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  train_split: "train"
+  valid_split: "dev"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 960_000
+    max_num_elements: 960_000
+    batch_shuffle_window: 1000
+    normalize_audio: true
+    example_shuffle_window: 1000
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+optimizer:
+  config:
+    lr: 5e-5
+
+lr_scheduler:
+  name: "tri_stage"
+  config:
+    stage_ratio: [0.1, 0.0, 0.9]
+    start_lr_scale: 0.01
+    final_lr_scale: 0.05
+
+gang:
+  timeout: 259200
+
+trainer:
+  freeze_encoder_for_n_steps: 0
+  mixed_precision:
+    dtype: "torch.bfloat16"
+  grad_accumulation:
+    num_batches: 16
+
+regime:
+  num_steps: 50_000
+  validate_after_n_steps: 500
+  validate_every_n_steps: 1000
+  checkpoint_every_n_steps: 1000
+  save_model_only: "all_but_last"
+  keep_last_n_checkpoints: 1
+  keep_best_n_checkpoints: 1
+  publish_metrics_every_n_steps: 100

--- a/docs/dtu_hpc/02-storage.md
+++ b/docs/dtu_hpc/02-storage.md
@@ -36,9 +36,9 @@ Request a temporary increase: email support@cc.dtu.dk. Only granted for limited 
 
 ---
 
-## GOTCHA: /work3 NVME pool has a 200 GB hard quota
+## GOTCHA: /work3 NVME pool has a 350 GB hard quota
 
-`/work3` spans multiple storage pools. The **NVME pool (pool 6)** has a **200 GB hard limit**.
+`/work3` spans multiple storage pools. The **NVME pool (pool 6)** has a **350 GB hard limit**.
 When this is hit, all `write()` calls fail silently — training jobs exit with code 120 and leave
 no traceback, making the root cause invisible.
 

--- a/docs/experiment-plan.md
+++ b/docs/experiment-plan.md
@@ -49,7 +49,7 @@ observed at step ~10k with val/WER ~47–49% and curves still clearly descending
 
 **Current quota status (2026-04-11):** quota upgraded to 350 GB (was 200 GB). Prior usage was ~87 GB.
 With pruning enabled, each 30k run uses ~7.4 GB (measured from E2). E3 + E5 + eval ≈ 25 GB total,
-leaving ~87 GB headroom. Safe to queue all three simultaneously.
+leaving ~238 GB headroom. Safe to queue all three simultaneously.
 
 ---
 

--- a/docs/experiment-plan.md
+++ b/docs/experiment-plan.md
@@ -37,7 +37,7 @@ observed at step ~10k with val/WER ~47–49% and curves still clearly descending
 
 ## Pre-flight Checklist (run before every experiment)
 
-1. **Check scratch quota:** `getquota_work3.sh` — storagepool 6 must be under 200 GB hard limit
+1. **Check scratch quota:** `getquota_work3.sh` — storagepool 6 must be under 350 GB hard limit
 2. **Clean old outputs:** `rm -rf /work3/$USER/outputs/<old_run>/` (W&B cache no longer accumulates — checkpoint artifact uploads are disabled in `run_training.py`)
 3. **Verify config has checkpoint pruning:**
    ```yaml
@@ -45,9 +45,9 @@ observed at step ~10k with val/WER ~47–49% and curves still clearly descending
      keep_last_n_checkpoints: 2
      keep_best_n_checkpoints: 1
    ```
-   Without this, 30k steps × ~4 GB/checkpoint = 120 GB, which reliably hits the 200 GB quota and kills the job silently with exit code 120.
+   Without this, 30k steps × ~4 GB/checkpoint = 120 GB, which can hit the 350 GB quota and kills the job silently with exit code 120.
 
-**Current quota status (2026-04-03):** 87.35 / 200 GB used on storagepool 6 → 112 GB free.
+**Current quota status (2026-04-11):** quota upgraded to 350 GB (was 200 GB). Prior usage was ~87 GB.
 With pruning enabled, each 30k run uses ~7.4 GB (measured from E2). E3 + E5 + eval ≈ 25 GB total,
 leaving ~87 GB headroom. Safe to queue all three simultaneously.
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -76,12 +76,12 @@ See [data-preparation.md](data-preparation.md) for full details.
 
 ## Scratch Space Management (MANDATORY for every training run)
 
-> **Gotcha:** `/work3` NVME pool (storagepool 6) has a **200 GB hard quota**. When hit, jobs exit
+> **Gotcha:** `/work3` NVME pool (storagepool 6) has a **350 GB hard quota**. When hit, jobs exit
 > silently with code 120 and leave no traceback. This has caused multiple lost training runs.
 
 **Before every job submission:**
 ```bash
-getquota_work3.sh          # storagepool 6 must be under 200 GB
+getquota_work3.sh          # storagepool 6 must be under 350 GB
 rm -rf /work3/$USER/outputs/<old_run>/   # remove runs you no longer need
 ```
 
@@ -99,7 +99,7 @@ regime:
 - Checkpoints: ~12 GB (3 × 4 GB max)
 - W&B cache: ~0 GB (no artifact uploads in `run_training.py`)
 - Caches/logs: ~2 GB
-- **Total: ~85 GB — well under the 200 GB limit**
+- **Total: ~85 GB — well under the 350 GB limit**
 
 ---
 

--- a/scripts/hpc/3b/15_train_e6_3b_50k_resume.sh
+++ b/scripts/hpc/3b/15_train_e6_3b_50k_resume.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#BSUB -J danish_asr_train_e6_3b_50k_resume
+#BSUB -q gpua100
+#BSUB -n 4
+#BSUB -R "rusage[mem=16GB]"
+#BSUB -R "span[hosts=1]"
+#BSUB -R "select[gpu80gb]"
+#BSUB -gpu "num=1:mode=exclusive_process"
+#BSUB -W 48:00
+#BSUB -B
+#BSUB -N
+#BSUB -u s204696@dtu.dk
+#BSUB -o /work3/s204696/logs/lsf/train_e6_3b_50k_resume_%J.out
+#BSUB -e /work3/s204696/logs/lsf/train_e6_3b_50k_resume_%J.err
+#
+# Resume the original 3B E6 workspace from 30k to 50k total steps.
+#
+# This script must point at the resolved fairseq2 workspace directory from the
+# completed 30k run, e.g.:
+#
+#   ORIGINAL_WS_DIR=/work3/$USER/outputs/omniasr_e6_3b/ws_1.<hash> \
+#       bsub < scripts/hpc/3b/15_train_e6_3b_50k_resume.sh
+#
+# Why this works:
+# - The continuation config sets `common.no_sweep_dir: true`, so fairseq2 uses
+#   the exact output directory below instead of creating a new `ws_*` child.
+# - fairseq2 then auto-resumes from the latest full checkpoint already present
+#   in that workspace. This script checks for `step_30000/trainer` up front to
+#   ensure the workspace contains resumable state, not just model weights.
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+RUN_DIR="${ORIGINAL_WS_DIR:-${RESUME_DIR:-}}"
+
+if [ -z "$RUN_DIR" ]; then
+    echo "ERROR: Set ORIGINAL_WS_DIR (or RESUME_DIR) to the original 3B workspace." >&2
+    echo "ERROR: Example: ORIGINAL_WS_DIR=/work3/\$USER/outputs/omniasr_e6_3b/ws_1.<hash> \\" >&2
+    echo "ERROR:            bsub < scripts/hpc/3b/15_train_e6_3b_50k_resume.sh" >&2
+    exit 1
+fi
+
+if [ ! -d "$RUN_DIR" ]; then
+    echo "ERROR: Workspace directory not found: $RUN_DIR" >&2
+    exit 1
+fi
+
+if [ ! -d "$RUN_DIR/checkpoints/step_30000/trainer" ]; then
+    echo "ERROR: Full resumable checkpoint not found at:" >&2
+    echo "ERROR:   $RUN_DIR/checkpoints/step_30000/trainer" >&2
+    echo "ERROR: This resume path requires the original full checkpoint state" >&2
+    echo "ERROR: (trainer/model/optimizer/data_reader), not only model weights." >&2
+    exit 1
+fi
+
+echo "=== Phase 10C: 3B Resume From 30k To 50k ==="
+echo "Workspace: $RUN_DIR"
+echo "Started:   $(date)"
+echo "Node:      $(hostname)"
+nvidia-smi
+
+python scripts/hpc/run_training.py \
+    --config configs/fairseq2/3b/ctc-finetune-hpc-e6-3b-50k.yaml \
+    --output-dir "$RUN_DIR" \
+    --wandb-tags "train,full,hpc,a100,80gb,3b,e6,50k,resume,from30k,lr5e-5,shuffle1000" \
+    --wandb-resume allow

--- a/scripts/hpc/run_training.py
+++ b/scripts/hpc/run_training.py
@@ -561,8 +561,8 @@ def main() -> None:
             if return_code == 120:
                 logger.error(
                     "Exit code 120: most likely /work3 NVME quota exhausted (storagepool 6, "
-                    "200 GB hard limit). Run getquota_work3.sh — if storagepool 6 is at or "
-                    "near 200 GB, that is the cause. Clean old checkpoint dirs and wandb/cache/. "
+                    "350 GB hard limit). Run getquota_work3.sh — if storagepool 6 is at or "
+                    "near 350 GB, that is the cause. Clean old checkpoint dirs and wandb/cache/. "
                     "If quota is fine, this is a CPython pipe-flush error at shutdown — "
                     "the real error should appear in the log above."
                 )
@@ -571,7 +571,7 @@ def main() -> None:
 
         # List checkpoints. Artifact uploads are disabled in this wrapper — wandb.log_artifact()
         # caches a full copy of every .pt file in WANDB_CACHE_DIR before uploading (4 GB/ckpt),
-        # which reliably exhausts the 200 GB /work3 NVME quota. Checkpoints stay on HPC scratch.
+        # which would consume large amounts of the 350 GB /work3 NVME quota. Checkpoints stay on HPC scratch.
         def _ckpt_step(p: Path) -> int:
             """Extract step number from checkpoint path (parent dir is step_N) for numeric sorting."""
             m = re.search(r"step_(\d+)", str(p))


### PR DESCRIPTION
Updates the HPC documentation and training-wrapper messaging to reflect the /work3 NVME pool quota increase from 200 GB to 350 GB, and refreshes the experiment plan and roadmap notes accordingly.