### PR TITLE
feature/3b eval matrix

### DIFF
--- a/configs/fairseq2/3b/ctc-eval-base-3b-conversation.yaml
+++ b/configs/fairseq2/3b/ctc-eval-base-3b-conversation.yaml
@@ -1,0 +1,39 @@
+# Zero-shot evaluation of pretrained omniASR_CTC_3B_v2 — conversation subset only.
+# No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
+#
+# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
+# No subset TSV required.
+#
+# Used by: scripts/hpc/3b/19_eval_base_3b.sh
+
+model:
+  name: "omniASR_CTC_3B_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  valid_split: "test_coral_v3_conversation"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 960_000
+    max_num_elements: 960_000
+    batch_shuffle_window: 1
+    normalize_audio: true
+    example_shuffle_window: 1
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+gang:
+  timeout: 86400
+
+evaluator:
+  amp: true
+  amp_dtype: "torch.bfloat16"

--- a/configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml
+++ b/configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml
@@ -1,0 +1,39 @@
+# Zero-shot evaluation of pretrained omniASR_CTC_3B_v2 — read_aloud subset only.
+# No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
+#
+# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
+# No subset TSV required.
+#
+# Used by: scripts/hpc/3b/19_eval_base_3b.sh
+
+model:
+  name: "omniASR_CTC_3B_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  valid_split: "test_coral_v3_read_aloud"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 960_000
+    max_num_elements: 960_000
+    batch_shuffle_window: 1
+    normalize_audio: true
+    example_shuffle_window: 1
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+gang:
+  timeout: 86400
+
+evaluator:
+  amp: true
+  amp_dtype: "torch.bfloat16"

--- a/configs/fairseq2/3b/ctc-eval-base-3b.yaml
+++ b/configs/fairseq2/3b/ctc-eval-base-3b.yaml
@@ -1,0 +1,37 @@
+# Zero-shot evaluation of pretrained omniASR_CTC_3B_v2 (no finetuning).
+# No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
+# Evaluates on the held-out TEST split (read_aloud + conversation combined).
+#
+# Used by: scripts/hpc/3b/19_eval_base_3b.sh
+
+model:
+  name: "omniASR_CTC_3B_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  valid_split: "test"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 960_000
+    max_num_elements: 960_000
+    batch_shuffle_window: 1
+    normalize_audio: true
+    example_shuffle_window: 1
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+gang:
+  timeout: 86400
+
+evaluator:
+  amp: true
+  amp_dtype: "torch.bfloat16"

--- a/configs/fairseq2/3b/ctc-eval-e6-3b-conversation.yaml
+++ b/configs/fairseq2/3b/ctc-eval-e6-3b-conversation.yaml
@@ -1,0 +1,43 @@
+# Evaluation of finetuned omniASR_CTC_3B_v2 (E6-3B, usual-totem-74, 30k steps) —
+# conversation subset only.
+#
+# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
+# No subset TSV required.
+#
+# Used by: scripts/hpc/3b/20_eval_e6_3b.sh
+# Checkpoint: /work3/s204696/outputs/omniasr_e6_3b/ws_1.2172dba0/checkpoints/step_30000/model
+
+model:
+  name: "omniASR_CTC_3B_v2"
+  family: "wav2vec2_asr"
+  arch: "3b_v2"
+  path: /work3/s204696/outputs/omniasr_e6_3b/ws_1.2172dba0/checkpoints/step_30000/model
+
+dataset:
+  name: "coral_v3_danish"
+  valid_split: "test_coral_v3_conversation"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 960_000
+    max_num_elements: 960_000
+    batch_shuffle_window: 1
+    normalize_audio: true
+    example_shuffle_window: 1
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+gang:
+  timeout: 86400
+
+evaluator:
+  amp: true
+  amp_dtype: "torch.bfloat16"

--- a/configs/fairseq2/3b/ctc-eval-e6-3b-read-aloud.yaml
+++ b/configs/fairseq2/3b/ctc-eval-e6-3b-read-aloud.yaml
@@ -1,0 +1,43 @@
+# Evaluation of finetuned omniASR_CTC_3B_v2 (E6-3B, usual-totem-74, 30k steps) —
+# read_aloud subset only.
+#
+# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
+# No subset TSV required.
+#
+# Used by: scripts/hpc/3b/20_eval_e6_3b.sh
+# Checkpoint: /work3/s204696/outputs/omniasr_e6_3b/ws_1.2172dba0/checkpoints/step_30000/model
+
+model:
+  name: "omniASR_CTC_3B_v2"
+  family: "wav2vec2_asr"
+  arch: "3b_v2"
+  path: /work3/s204696/outputs/omniasr_e6_3b/ws_1.2172dba0/checkpoints/step_30000/model
+
+dataset:
+  name: "coral_v3_danish"
+  valid_split: "test_coral_v3_read_aloud"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 960_000
+    max_num_elements: 960_000
+    batch_shuffle_window: 1
+    normalize_audio: true
+    example_shuffle_window: 1
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+gang:
+  timeout: 86400
+
+evaluator:
+  amp: true
+  amp_dtype: "torch.bfloat16"

--- a/docs/evaluation-results.md
+++ b/docs/evaluation-results.md
@@ -15,7 +15,8 @@ treated as provisional until eval filtering is fully verified.
 | `omniASR_CTC_300M_v2` | finetuned E6 | 50k | **30.73%** | `balmy-vortex-87` | lr=`5e-5`, shuffle=`1000` |
 | `omniASR_CTC_1B_v2` | base (zero-shot) | — | **55.39%** | `true-sound-81` | pretrained model, no finetuning |
 | `omniASR_CTC_1B_v2` | finetuned E6-1B | 50k | **23.43%** | `deep-fire-90` | lr=`5e-5`, shuffle=`1000` |
-| `omniASR_CTC_3B_v2` | finetuned E6-3B | 30k | pending | — | combined test eval added in `feature/3b-eval-matrix` |
+| `omniASR_CTC_3B_v2` | base (zero-shot) | — | pending | — | base 3B eval script added; not yet run |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | 30k | **23.06%** | `lunar-rain-93` | lr=`5e-5`, shuffle=`1000`; beats `1B E6-1B 50k` by `0.38pp` |
 
 ## Split-Tagged Results
 
@@ -32,13 +33,19 @@ final benchmark evidence until split-aware eval filtering is confirmed.
 | `omniASR_CTC_1B_v2` | base (zero-shot) | `conversation` | **56.42%** | `charmed-rain-83` |
 | `omniASR_CTC_1B_v2` | finetuned E6-1B | `read_aloud` | **20.98%** | `upbeat-tree-91` |
 | `omniASR_CTC_1B_v2` | finetuned E6-1B | `conversation` | **26.49%** | `silvery-durian-92` |
+| `omniASR_CTC_3B_v2` | base (zero-shot) | `read_aloud` | pending | — |
+| `omniASR_CTC_3B_v2` | base (zero-shot) | `conversation` | pending | — |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `read_aloud` | pending | — |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `conversation` | pending | — |
 
 ## Takeaways
 
 - Finetuning is the main source of gain: `300M` improves from `68.18%` to `30.73%`, and `1B` improves from `55.39%` to `23.43%`.
 - Scaling from `300M` to `1B` remains very valuable after finetuning: `30.73%` to `23.43%` on the combined test split.
 - Conversation remains harder than read-aloud in the current split-tagged runs.
-- `1B E6-1B 50k` is the strongest fully evaluated non-3B checkpoint so far.
+- `3B E6-3B 30k` is the current best combined-test result at `23.06%`, but it improves on `1B E6-1B 50k` by only `0.38pp` (`23.43%` -> `23.06%`).
+- That means scaling from `1B` to `3B` is still helping, but only modestly relative to the extra compute already spent to reach the 3B checkpoint.
+- `3B` zero-shot and split-tagged evaluations are now wired in the repo, but those runs still need to be submitted before the pending rows above can be filled.
 
 ## Related Docs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Fine-tuning Meta's Omnilingual ASR (`omniASR_CTC_300M_v2`) for Danish using CoRa
 | Document | Description |
 |---|---|
 | [Project Roadmap](project-roadmap.md) | End-to-end plan with phases, timelines, and resource budget |
-| [Evaluation Results](evaluation-results.md) | Central table of current 300M and 1B test results, with 3B eval pending |
+| [Evaluation Results](evaluation-results.md) | Central table of current 300M, 1B, and 3B test results |
 | [Omnilingual ASR Overview](omnilingual-asr-overview.md) | Model architecture, variants, installation, and inference |
 | [CoRal Dataset](coral-dataset.md) | Dataset splits, fields, demographics, and loading |
 | [Data Preparation](data-preparation.md) | Converting CoRal-v3 to the required Parquet format |

--- a/scripts/hpc/3b/19_eval_base_3b.sh
+++ b/scripts/hpc/3b/19_eval_base_3b.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#BSUB -J danish_asr_eval_e6_3b
+#BSUB -J danish_asr_eval_base_3b
 #BSUB -q gpua100
 #BSUB -n 4
 #BSUB -R "rusage[mem=16GB]"
@@ -10,36 +10,36 @@
 #BSUB -B
 #BSUB -N
 #BSUB -u s204696@dtu.dk
-#BSUB -o /work3/s204696/logs/lsf/eval_e6_3b_%J.out
-#BSUB -e /work3/s204696/logs/lsf/eval_e6_3b_%J.err
+#BSUB -o /work3/s204696/logs/lsf/eval_base_3b_%J.out
+#BSUB -e /work3/s204696/logs/lsf/eval_base_3b_%J.err
 #
-# Evaluate finetuned omniASR_CTC_3B_v2 (E6-3B, 30k steps) on 3 test splits.
-# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format,
-# matching the proven 300M / 1B eval flow.
+# Zero-shot evaluation of pretrained omniASR_CTC_3B_v2 on 3 test splits.
+# No checkpoint needed — model loaded from fairseq2 asset registry.
+# Walltime 4:00 covers 3 sequential splits on A100-80GB.
 #
 # Usage:
-#   bsub < scripts/hpc/3b/20_eval_e6_3b.sh
+#   bsub < scripts/hpc/3b/19_eval_base_3b.sh
 #
 # Single-split override:
-#   EVAL_CONFIG=configs/fairseq2/3b/ctc-eval-e6-3b-read-aloud.yaml \
-#       bsub < scripts/hpc/3b/20_eval_e6_3b.sh
+#   EVAL_CONFIG=configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml \
+#       bsub < scripts/hpc/3b/19_eval_base_3b.sh
 
 set -euo pipefail
 
 source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
 setup_omniasr
 
-EVAL_OUT_DIR="${EVAL_OUT_DIR:-/work3/$USER/outputs/omniasr_e6_3b_eval}"
+EVAL_OUT_DIR="${EVAL_OUT_DIR:-/work3/$USER/outputs/omniasr_base_3b_eval}"
 if ! mkdir -p "$EVAL_OUT_DIR" 2>/dev/null; then
     echo "ERROR: Cannot create eval workspace: $EVAL_OUT_DIR" >&2
     echo "ERROR: Check /work3 quota with getquota_work3.sh" >&2
     exit 1
 fi
 
-echo "=== Phase 10C: 3B Finetuned E6-3B Evaluation ==="
-echo "Eval workspace:     $EVAL_OUT_DIR"
-echo "Started:            $(date)"
-echo "Node:               $(hostname)"
+echo "=== Phase 10C: 3B Base (Zero-Shot) Evaluation ==="
+echo "Eval workspace: $EVAL_OUT_DIR"
+echo "Started:        $(date)"
+echo "Node:           $(hostname)"
 nvidia-smi
 
 had_failures=0
@@ -53,14 +53,14 @@ split_tag() {
 }
 
 CONFIGS=(
-    "configs/fairseq2/3b/ctc-eval-e6-3b.yaml"
-    "configs/fairseq2/3b/ctc-eval-e6-3b-read-aloud.yaml"
-    "configs/fairseq2/3b/ctc-eval-e6-3b-conversation.yaml"
+    "configs/fairseq2/3b/ctc-eval-base-3b.yaml"
+    "configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml"
+    "configs/fairseq2/3b/ctc-eval-base-3b-conversation.yaml"
 )
 
 for i in "${!CONFIGS[@]}"; do
     CONFIG="${EVAL_CONFIG:-${CONFIGS[$i]}}"
-    TAGS="e6-3b,3b,30k,lr5e-5,shuffle1000,test,$(split_tag "$CONFIG")"
+    TAGS="base,3b,zero-shot,test,$(split_tag "$CONFIG")"
     echo ""
     echo "--- Split $((i+1))/3: $CONFIG ---"
 

--- a/scripts/hpc/submit_eval_matrix.sh
+++ b/scripts/hpc/submit_eval_matrix.sh
@@ -4,9 +4,10 @@
 # - 300M E6: 3 configs
 # - 1B base: 3 configs
 # - 1B E6: 3 configs
-# - 3B E6-3B: 1 config (combined only)
+# - 3B base: 3 configs
+# - 3B E6-3B: 3 configs
 #
-# Total: 13 eval runs submitted across 5 batch scripts.
+# Total: 18 eval runs submitted across 6 batch scripts.
 #
 # Usage:
 #   ./scripts/hpc/submit_eval_matrix.sh
@@ -25,6 +26,7 @@ SCRIPTS=(
     "$SCRIPT_DIR/300m/21_eval_e6_full.sh"
     "$SCRIPT_DIR/1b/20_eval_base_1b.sh"
     "$SCRIPT_DIR/1b/21_eval_e6_1b.sh"
+    "$SCRIPT_DIR/3b/19_eval_base_3b.sh"
     "$SCRIPT_DIR/3b/20_eval_e6_3b.sh"
 )
 LABELS=(
@@ -32,10 +34,11 @@ LABELS=(
     "300M finetuned (E6, 50k)"
     "1B base (zero-shot)"
     "1B finetuned (E6-1B, 50k)"
-    "3B finetuned (E6-3B, 30k, combined)"
+    "3B base (zero-shot)"
+    "3B finetuned (E6-3B, 30k)"
 )
 
-echo "=== Submitting Eval Matrix (5 jobs, 13 eval runs total) ==="
+echo "=== Submitting Eval Matrix (6 jobs, 18 eval runs total) ==="
 echo ""
 
 for i in "${!SCRIPTS[@]}"; do


### PR DESCRIPTION
- **Refine checkpoint upload artifact metadata**
- **Add Phase 8B eval matrix: 4 models x 3 splits (12 eval runs)**
- **Fix eval matrix scripts: walltime, W&B tags, docs**
- **Harden eval matrix scripts and upload helper**
- **Add 3B 30k training config and submit script**
- **Update experiment plan with eval job status**
- **Fix 1B eval configs: add family and arch fields required by fairseq2**
- **Add Phase 8B results and fix run_eval.py WER parser**
- **Fix wrapped eval metric parsing**
- **Fix subset eval split filtering**
- **Move subset TSV helper to legacy**
- **Reduce 3B checkpoint storage pressure**
- **Fix stale eval script comments**
- **Update work3 quota documentation**
- **Add 3B resume-to-50k config and script**
- **Add 3B eval matrix support**
- **Add evaluation results document**
- **Remove enviroment variable and hardcoding config**
- **Add 3B base and split evaluation jobs**
