### PR TITLE
[codex] Add KenLM decoding pipeline for OmniASR CTC

### DIFF
--- a/configs/lm/coral_train_only_hpc_s204696.yaml
+++ b/configs/lm/coral_train_only_hpc_s204696.yaml
@@ -1,0 +1,13 @@
+name: danish_lm_v1
+
+source:
+  dataset_root: /work3/s204696/data/parquet/version=0
+  split: train
+  language: dan_Latn
+  corpora:
+    - coral_v3_read_aloud
+    - coral_v3_conversation
+
+output:
+  corpus_text_path: /work3/s204696/data/lm/processed/danish_lm_v1.txt
+  stats_path: /work3/s204696/data/lm/processed/danish_lm_v1.stats.json

--- a/configs/lm/coral_train_only_v1.yaml
+++ b/configs/lm/coral_train_only_v1.yaml
@@ -1,0 +1,13 @@
+name: danish_lm_v1
+
+source:
+  dataset_root: data/parquet/version=0
+  split: train
+  language: dan_Latn
+  corpora:
+    - coral_v3_read_aloud
+    - coral_v3_conversation
+
+output:
+  corpus_text_path: data/lm/processed/danish_lm_v1.txt
+  stats_path: data/lm/processed/danish_lm_v1.stats.json

--- a/docs/evaluation-results.md
+++ b/docs/evaluation-results.md
@@ -15,7 +15,7 @@ treated as provisional until eval filtering is fully verified.
 | `omniASR_CTC_300M_v2` | finetuned E6 | 50k | **30.73%** | `balmy-vortex-87` | lr=`5e-5`, shuffle=`1000` |
 | `omniASR_CTC_1B_v2` | base (zero-shot) | — | **55.39%** | `true-sound-81` | pretrained model, no finetuning |
 | `omniASR_CTC_1B_v2` | finetuned E6-1B | 50k | **23.43%** | `deep-fire-90` | lr=`5e-5`, shuffle=`1000` |
-| `omniASR_CTC_3B_v2` | base (zero-shot) | — | pending | — | base 3B eval script added; not yet run |
+| `omniASR_CTC_3B_v2` | base (zero-shot) | — | **52.87%** | `distinctive-glade-94` | pretrained model, no finetuning |
 | `omniASR_CTC_3B_v2` | finetuned E6-3B | 30k | **23.06%** | `lunar-rain-93` | lr=`5e-5`, shuffle=`1000`; beats `1B E6-1B 50k` by `0.38pp` |
 
 ## Split-Tagged Results
@@ -33,19 +33,40 @@ final benchmark evidence until split-aware eval filtering is confirmed.
 | `omniASR_CTC_1B_v2` | base (zero-shot) | `conversation` | **56.42%** | `charmed-rain-83` |
 | `omniASR_CTC_1B_v2` | finetuned E6-1B | `read_aloud` | **20.98%** | `upbeat-tree-91` |
 | `omniASR_CTC_1B_v2` | finetuned E6-1B | `conversation` | **26.49%** | `silvery-durian-92` |
-| `omniASR_CTC_3B_v2` | base (zero-shot) | `read_aloud` | pending | — |
-| `omniASR_CTC_3B_v2` | base (zero-shot) | `conversation` | pending | — |
-| `omniASR_CTC_3B_v2` | finetuned E6-3B | `read_aloud` | pending | — |
-| `omniASR_CTC_3B_v2` | finetuned E6-3B | `conversation` | pending | — |
+| `omniASR_CTC_3B_v2` | base (zero-shot) | `read_aloud` | **52.22%** | `legendary-monkey-95` |
+| `omniASR_CTC_3B_v2` | base (zero-shot) | `conversation` | **53.68%** | `jumping-leaf-96` |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `read_aloud` | **20.16%** | `lilac-pine-98` |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `conversation` | **26.69%** | `toasty-terrain-99` |
 
 ## Takeaways
 
 - Finetuning is the main source of gain: `300M` improves from `68.18%` to `30.73%`, and `1B` improves from `55.39%` to `23.43%`.
 - Scaling from `300M` to `1B` remains very valuable after finetuning: `30.73%` to `23.43%` on the combined test split.
 - Conversation remains harder than read-aloud in the current split-tagged runs.
+- `3B` follows the same pattern: base `52.87%` -> finetuned `23.06%`, with `read_aloud` easier (`20.16%`) than `conversation` (`26.69%`).
 - `3B E6-3B 30k` is the current best combined-test result at `23.06%`, but it improves on `1B E6-1B 50k` by only `0.38pp` (`23.43%` -> `23.06%`).
 - That means scaling from `1B` to `3B` is still helping, but only modestly relative to the extra compute already spent to reach the 3B checkpoint.
-- `3B` zero-shot and split-tagged evaluations are now wired in the repo, but those runs still need to be submitted before the pending rows above can be filled.
+
+## LM Decoding Results
+
+Iteration 1 keeps LM construction deliberately narrow: the KenLM corpus is built from
+`CoRal v3` `train` transcripts only, using the same local fairseq2 parquet source as
+the omniASR training/eval pipeline. That avoids validation/test leakage while keeping
+the first decoding experiment easy to reproduce.
+
+| Model | Training | Split | Decoder | LM | Beam | Alpha | Beta | WER | Notes |
+|---|---|---|---|---|---:|---:|---:|---:|---|
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `greedy` | `none` | — | — | — | — | to be filled from `scripts/decode_ctc_with_lm.py` |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `none` | `64` | `0.0` | `0.0` | — | first non-LM beam-search comparison |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.3` | `0.0` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.3` | `0.5` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.3` | `1.0` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.6` | `0.0` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.6` | `0.5` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.6` | `1.0` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.9` | `0.0` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.9` | `0.5` | — | iteration-1 tuning grid |
+| `omniASR_CTC_3B_v2` | finetuned E6-3B | `combined` | `beam` | `danish_lm_v1_3gram` | `64` | `0.9` | `1.0` | — | iteration-1 tuning grid |
 
 ## Related Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "soundfile>=0.12.0",
     "peft>=0.10.0",
     "jiwer>=3.0.0",
+    "pyctcdecode>=0.5.0",
     "accelerate>=0.28.0",
     # DVC
     "dvc>=3.0.0",

--- a/scripts/decode_ctc_with_lm.py
+++ b/scripts/decode_ctc_with_lm.py
@@ -1,0 +1,270 @@
+"""Run standalone CTC decoding for OmniASR checkpoints with greedy or pyctcdecode beam search."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from fairseq2.nn.batch_layout import BatchLayout
+from loguru import logger
+
+from danish_asr.lm import (
+    DecodeResult,
+    build_pyctcdecode_labels,
+    collate_decode_records,
+    decode_logits_with_argmax,
+    infer_split_from_eval_config,
+    iter_fairseq2_rows,
+    make_decoder_factory,
+    make_inference_pipeline,
+    parse_valid_split,
+    resolve_dtype,
+    score_predictions,
+    strip_special_tokens,
+    write_text_lines,
+)
+from danish_asr.utils import configure_project_cache_environment, get_device, resolve_project_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--eval-config", default=None)
+    parser.add_argument("--checkpoint-path", default=None)
+    parser.add_argument("--model-arch", default=None)
+    parser.add_argument("--dataset-root", default=None)
+    parser.add_argument("--dataset-split", default=None)
+    parser.add_argument("--tokenizer-name", default="omniASR_tokenizer_written_v2")
+    parser.add_argument("--tokenizer-model-path", "--vocab-path", dest="tokenizer_model_path", default=None)
+    parser.add_argument("--decoder", choices=("greedy", "beam"), default="greedy")
+    parser.add_argument("--kenlm-binary", default=None)
+    parser.add_argument("--beam-width", type=int, default=64)
+    parser.add_argument("--alpha", type=float, default=0.6)
+    parser.add_argument("--beta", type=float, default=0.5)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--dtype", choices=("float32", "float16", "bfloat16"), default="bfloat16")
+    parser.add_argument("--max-samples", type=int, default=None)
+    parser.add_argument("--output-dir", required=True)
+    return parser.parse_args()
+
+
+def _resolve_inputs(args: argparse.Namespace) -> dict[str, str]:
+    if args.eval_config:
+        inferred = infer_split_from_eval_config(args.eval_config)
+        return {
+            "checkpoint_path": str(inferred["checkpoint_path"]),
+            "model_arch": inferred["model_arch"],
+            "dataset_root": str(inferred["dataset_root"]),
+            "dataset_split": inferred["valid_split"],
+            "tokenizer_name": inferred["tokenizer_name"],
+        }
+
+    required = {
+        "checkpoint_path": args.checkpoint_path,
+        "model_arch": args.model_arch,
+        "dataset_root": args.dataset_root,
+        "dataset_split": args.dataset_split,
+        "tokenizer_name": args.tokenizer_name,
+    }
+    missing = [key for key, value in required.items() if value is None]
+    if missing:
+        msg = "When --eval-config is not provided, the following arguments are required: " + ", ".join(
+            f"--{name.replace('_', '-')}" for name in missing
+        )
+        raise ValueError(msg)
+
+    return {key: str(value) for key, value in required.items()}
+
+
+def _decode_batch(
+    *,
+    audio_payloads: list[bytes],
+    references: list[str],
+    corpora: list[str],
+    files: list[str],
+    row_indices: list[int],
+    pipeline,
+    decoder_kind: str,
+    beam_decoder,
+    beam_width: int,
+    removable_tokens: set[str],
+) -> list[DecodeResult]:
+    audio_tensors = list(pipeline._build_audio_wavform_pipeline(audio_payloads).and_return())
+    batch = pipeline._create_batch_simple([(audio_tensor, None) for audio_tensor in audio_tensors])
+    batch_layout = BatchLayout(
+        batch.source_seqs.shape,
+        seq_lens=batch.source_seq_lens,
+        device=batch.source_seqs.device,
+    )
+    logits, output_layout = pipeline.model(batch.source_seqs, batch_layout)
+
+    token_decoder = pipeline.token_decoder
+    decoded: list[str] = []
+
+    for index in range(logits.shape[0]):
+        seq_len = int(output_layout.seq_lens[index])
+        logit_slice = logits[index, :seq_len]
+
+        if decoder_kind == "greedy":
+            hypothesis = decode_logits_with_argmax(logit_slice, seq_len=seq_len, token_decoder=token_decoder)
+        else:
+            if beam_decoder is None:
+                raise ValueError("Beam decoder must be initialized when --decoder beam is selected.")
+
+            hypothesis = beam_decoder.decode(logit_slice.float().cpu().numpy(), beam_width=beam_width)
+            hypothesis = strip_special_tokens(hypothesis, removable_tokens)
+
+        decoded.append(hypothesis)
+
+    return [
+        DecodeResult(
+            prediction=prediction,
+            reference=reference,
+            corpus=corpus,
+            file=file_path,
+            row_index=row_index,
+        )
+        for prediction, reference, corpus, file_path, row_index in zip(
+            decoded, references, corpora, files, row_indices, strict=True
+        )
+    ]
+
+
+def main() -> None:
+    configure_project_cache_environment()
+    args = parse_args()
+    resolved = _resolve_inputs(args)
+
+    output_dir = resolve_project_path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    device = get_device()
+    dtype = resolve_dtype(args.dtype, device)
+
+    pipeline, tokenizer_model_path = make_inference_pipeline(
+        checkpoint_path=resolved["checkpoint_path"],
+        model_arch=resolved["model_arch"],
+        tokenizer_name=resolved["tokenizer_name"],
+        tokenizer_model_path=args.tokenizer_model_path,
+        device=device,
+        dtype=dtype,
+    )
+
+    split_name, corpus_name = parse_valid_split(resolved["dataset_split"])
+    corpora = (corpus_name,) if corpus_name else None
+
+    beam_decoder = None
+    removable_tokens: set[str] = set()
+    if args.decoder == "beam":
+        labels, removable_tokens = build_pyctcdecode_labels(tokenizer_model_path)
+        beam_decoder = make_decoder_factory(
+            labels,
+            kenlm_model_path=args.kenlm_binary,
+            alpha=args.alpha,
+            beta=args.beta,
+        )
+
+    batch_payloads: list[bytes] = []
+    batch_refs: list[str] = []
+    batch_corpora: list[str] = []
+    batch_files: list[str] = []
+    batch_rows: list[int] = []
+    results: list[DecodeResult] = []
+
+    for example_index, row in enumerate(
+        iter_fairseq2_rows(
+            Path(resolved["dataset_root"]),
+            split=split_name,
+            corpora=corpora,
+            columns=("text", "audio_bytes"),
+        )
+    ):
+        batch_payloads.append(row["audio_bytes"])
+        batch_refs.append(str(row["text"]))
+        batch_corpora.append(str(row["corpus"]))
+        batch_files.append(str(row["file"]))
+        batch_rows.append(int(row["row_index"]))
+
+        should_flush = len(batch_payloads) >= args.batch_size
+        reached_limit = args.max_samples is not None and example_index + 1 >= args.max_samples
+        if should_flush or reached_limit:
+            results.extend(
+                _decode_batch(
+                    audio_payloads=batch_payloads,
+                    references=batch_refs,
+                    corpora=batch_corpora,
+                    files=batch_files,
+                    row_indices=batch_rows,
+                    pipeline=pipeline,
+                    decoder_kind=args.decoder,
+                    beam_decoder=beam_decoder,
+                    beam_width=args.beam_width,
+                    removable_tokens=removable_tokens,
+                )
+            )
+            batch_payloads = []
+            batch_refs = []
+            batch_corpora = []
+            batch_files = []
+            batch_rows = []
+
+        if reached_limit:
+            break
+
+    if batch_payloads:
+        results.extend(
+            _decode_batch(
+                audio_payloads=batch_payloads,
+                references=batch_refs,
+                corpora=batch_corpora,
+                files=batch_files,
+                row_indices=batch_rows,
+                pipeline=pipeline,
+                decoder_kind=args.decoder,
+                beam_decoder=beam_decoder,
+                beam_width=args.beam_width,
+                removable_tokens=removable_tokens,
+            )
+        )
+
+    predictions, references = collate_decode_records(results)
+    predictions_path = output_dir / "predictions.txt"
+    references_path = output_dir / "references.txt"
+    records_path = output_dir / "records.jsonl"
+    metadata_path = output_dir / "metadata.json"
+    score_path = output_dir / "scores.json"
+
+    write_text_lines(predictions_path, predictions)
+    write_text_lines(references_path, references)
+    records_path.write_text(
+        "".join(json.dumps(result.__dict__, ensure_ascii=False) + "\n" for result in results),
+        encoding="utf-8",
+    )
+
+    metadata = {
+        "checkpoint_path": resolved["checkpoint_path"],
+        "model_arch": resolved["model_arch"],
+        "dataset_root": resolved["dataset_root"],
+        "dataset_split": resolved["dataset_split"],
+        "tokenizer_name": resolved["tokenizer_name"],
+        "tokenizer_model_path": str(tokenizer_model_path),
+        "decoder": args.decoder,
+        "kenlm_binary": args.kenlm_binary,
+        "beam_width": args.beam_width,
+        "alpha": args.alpha,
+        "beta": args.beta,
+        "batch_size": args.batch_size,
+        "dtype": str(dtype),
+        "num_examples": len(results),
+    }
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+    score_summary = score_predictions(predictions, references)
+    score_path.write_text(json.dumps(score_summary, indent=2) + "\n", encoding="utf-8")
+
+    logger.info("Decoded {} examples -> {}", len(results), output_dir)
+    logger.info("WER: {:.2f}%", score_summary["wer"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_ctc_predictions.py
+++ b/scripts/evaluate_ctc_predictions.py
@@ -1,0 +1,35 @@
+"""Compute WER from saved prediction and reference text files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from danish_asr.lm import read_text_lines, score_predictions
+from danish_asr.utils import resolve_project_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--predictions", required=True)
+    parser.add_argument("--references", required=True)
+    parser.add_argument("--output-json", default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    predictions = read_text_lines(args.predictions)
+    references = read_text_lines(args.references)
+    summary = score_predictions(predictions, references)
+
+    if args.output_json:
+        output_path = resolve_project_path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hpc/build_kenlm.sh
+++ b/scripts/hpc/build_kenlm.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#BSUB -J danish_asr_build_kenlm
+#BSUB -q hpc
+#BSUB -n 1
+#BSUB -R "rusage[mem=16GB]"
+#BSUB -W 04:00
+#BSUB -o /work3/s204696/logs/lsf/build_kenlm_%J.out
+#BSUB -e /work3/s204696/logs/lsf/build_kenlm_%J.err
+#
+# Build the iteration-1 3-gram KenLM artifact from the prepared Danish LM text
+# corpus on work3.
+#
+# Usage:
+#   bsub < scripts/hpc/build_kenlm.sh
+#
+# Optional overrides:
+#   LM_TEXT_PATH=/work3/$USER/data/lm/processed/danish_lm_v1.txt
+#   KENLM_OUTPUT_PREFIX=/work3/$USER/artifacts/lm/danish_lm_v1_3gram
+#   LMPLZ_BIN=/path/to/lmplz
+#   BUILD_BINARY_BIN=/path/to/build_binary
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+LM_TEXT_PATH="${LM_TEXT_PATH:-/work3/$USER/data/lm/processed/danish_lm_v1.txt}"
+KENLM_OUTPUT_PREFIX="${KENLM_OUTPUT_PREFIX:-/work3/$USER/artifacts/lm/danish_lm_v1_3gram}"
+LMPLZ_BIN="${LMPLZ_BIN:-lmplz}"
+BUILD_BINARY_BIN="${BUILD_BINARY_BIN:-build_binary}"
+
+uv sync
+
+uv run python scripts/lm/build_kenlm.py \
+    --config configs/lm/coral_train_only_hpc_s204696.yaml \
+    --text-path "$LM_TEXT_PATH" \
+    --output-prefix "$KENLM_OUTPUT_PREFIX" \
+    --lmplz-bin "$LMPLZ_BIN" \
+    --build-binary-bin "$BUILD_BINARY_BIN"

--- a/scripts/hpc/build_lm_corpus.sh
+++ b/scripts/hpc/build_lm_corpus.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#BSUB -J danish_asr_build_lm_corpus
+#BSUB -q hpc
+#BSUB -n 1
+#BSUB -R "rusage[mem=8GB]"
+#BSUB -W 02:00
+#BSUB -o /work3/s204696/logs/lsf/build_lm_corpus_%J.out
+#BSUB -e /work3/s204696/logs/lsf/build_lm_corpus_%J.err
+#
+# Build the iteration-1 Danish KenLM text corpus from CoRal v3 train transcripts
+# already converted into local fairseq2 parquet shards on work3.
+#
+# Usage:
+#   bsub < scripts/hpc/build_lm_corpus.sh
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+uv sync
+
+uv run python scripts/lm/build_danish_lm_corpus.py \
+    --config configs/lm/coral_train_only_hpc_s204696.yaml

--- a/scripts/hpc/decode_with_lm.sh
+++ b/scripts/hpc/decode_with_lm.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#BSUB -J danish_asr_decode_lm
+#BSUB -q gpua100
+#BSUB -n 4
+#BSUB -R "rusage[mem=16GB]"
+#BSUB -R "span[hosts=1]"
+#BSUB -R "select[gpu80gb]"
+#BSUB -gpu "num=1:mode=exclusive_process"
+#BSUB -W 12:00
+#BSUB -o /work3/s204696/logs/lsf/decode_lm_%J.out
+#BSUB -e /work3/s204696/logs/lsf/decode_lm_%J.err
+
+# Standalone LM-decoding grid for OmniASR CTC checkpoints.
+#
+# Usage example:
+#   KENLM_BINARY=/work3/$USER/artifacts/lm/danish_lm_v1_3gram.bin \
+#   bsub < scripts/hpc/decode_with_lm.sh
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+PROJECT_DIR="${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}"
+OUTPUT_ROOT="${LM_DECODE_OUTPUT_DIR:-/work3/$USER/outputs/lm_decode_3b_e6_combined}"
+EVAL_CONFIG="${EVAL_CONFIG:-configs/fairseq2/3b/ctc-eval-e6-3b.yaml}"
+KENLM_BINARY="${KENLM_BINARY:-}"
+TOKENIZER_MODEL_PATH="${TOKENIZER_MODEL_PATH:-}"
+BEAM_WIDTH="${BEAM_WIDTH:-64}"
+ALPHAS="${ALPHAS:-0.3 0.6 0.9}"
+BETAS="${BETAS:-0.0 0.5 1.0}"
+BATCH_SIZE="${BATCH_SIZE:-2}"
+
+mkdir -p "$OUTPUT_ROOT"
+
+TOKENIZER_ARGS=()
+if [ -n "$TOKENIZER_MODEL_PATH" ]; then
+    TOKENIZER_ARGS+=(--tokenizer-model-path "$TOKENIZER_MODEL_PATH")
+fi
+
+python "$PROJECT_DIR/scripts/decode_ctc_with_lm.py" \
+    --eval-config "$EVAL_CONFIG" \
+    --decoder greedy \
+    --batch-size "$BATCH_SIZE" \
+    --output-dir "$OUTPUT_ROOT/greedy"
+
+python "$PROJECT_DIR/scripts/evaluate_ctc_predictions.py" \
+    --predictions "$OUTPUT_ROOT/greedy/predictions.txt" \
+    --references "$OUTPUT_ROOT/greedy/references.txt" \
+    --output-json "$OUTPUT_ROOT/greedy/score.json"
+
+python "$PROJECT_DIR/scripts/decode_ctc_with_lm.py" \
+    --eval-config "$EVAL_CONFIG" \
+    --decoder beam \
+    --beam-width "$BEAM_WIDTH" \
+    --batch-size "$BATCH_SIZE" \
+    "${TOKENIZER_ARGS[@]}" \
+    --output-dir "$OUTPUT_ROOT/beam_no_lm"
+
+python "$PROJECT_DIR/scripts/evaluate_ctc_predictions.py" \
+    --predictions "$OUTPUT_ROOT/beam_no_lm/predictions.txt" \
+    --references "$OUTPUT_ROOT/beam_no_lm/references.txt" \
+    --output-json "$OUTPUT_ROOT/beam_no_lm/score.json"
+
+if [ -z "$KENLM_BINARY" ]; then
+    echo "KENLM_BINARY is unset; skipping LM-backed decoding grid."
+    exit 0
+fi
+
+for ALPHA in $ALPHAS; do
+    for BETA in $BETAS; do
+        RUN_DIR="$OUTPUT_ROOT/beam_lm_a${ALPHA}_b${BETA}"
+
+        python "$PROJECT_DIR/scripts/decode_ctc_with_lm.py" \
+            --eval-config "$EVAL_CONFIG" \
+            --decoder beam \
+            --kenlm-binary "$KENLM_BINARY" \
+            --beam-width "$BEAM_WIDTH" \
+            --alpha "$ALPHA" \
+            --beta "$BETA" \
+            --batch-size "$BATCH_SIZE" \
+            "${TOKENIZER_ARGS[@]}" \
+            --output-dir "$RUN_DIR"
+
+        python "$PROJECT_DIR/scripts/evaluate_ctc_predictions.py" \
+            --predictions "$RUN_DIR/predictions.txt" \
+            --references "$RUN_DIR/references.txt" \
+            --output-json "$RUN_DIR/score.json"
+    done
+done

--- a/scripts/lm/__init__.py
+++ b/scripts/lm/__init__.py
@@ -1,0 +1,1 @@
+"""LM-related helper scripts."""

--- a/scripts/lm/build_danish_lm_corpus.py
+++ b/scripts/lm/build_danish_lm_corpus.py
@@ -1,0 +1,51 @@
+"""Build a deterministic Danish KenLM text corpus from local fairseq2 parquet shards."""
+
+from __future__ import annotations
+
+import argparse
+
+from loguru import logger
+
+from danish_asr.lm import (
+    build_lm_corpus_from_parquet,
+    load_yaml_config,
+    write_corpus_stats,
+    write_lm_corpus,
+)
+from danish_asr.utils import configure_project_cache_environment
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="configs/lm/coral_train_only_v1.yaml")
+    return parser.parse_args()
+
+
+def main() -> None:
+    configure_project_cache_environment()
+    args = parse_args()
+    config = load_yaml_config(args.config)
+
+    source = config["source"]
+    output = config["output"]
+
+    texts, stats = build_lm_corpus_from_parquet(
+        source["dataset_root"],
+        split=source.get("split", "train"),
+        language=source.get("language", "dan_Latn"),
+        corpora=tuple(source["corpora"]),
+    )
+
+    write_lm_corpus(texts, output["corpus_text_path"])
+    write_corpus_stats(stats, output["stats_path"])
+
+    logger.info(
+        "Built LM corpus with {} unique lines / {} tokens from {} raw examples.",
+        stats.unique_examples,
+        stats.token_count,
+        stats.raw_examples,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lm/build_kenlm.py
+++ b/scripts/lm/build_kenlm.py
@@ -1,0 +1,62 @@
+"""Build a KenLM 3-gram model from a prepared text corpus."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from contextlib import ExitStack
+from pathlib import Path
+
+from loguru import logger
+
+from danish_asr.lm import load_yaml_config
+from danish_asr.utils import resolve_project_path
+
+
+def run_kenlm_command(command: list[str], *, stdin_path: Path | None = None, stdout_path: Path | None = None) -> None:
+    """Run a KenLM binary with optional redirected stdin/stdout."""
+    logger.info("Running: {}", " ".join(command))
+
+    with ExitStack() as stack:
+        stdin_handle = stack.enter_context(stdin_path.open("rb")) if stdin_path is not None else None
+        stdout_handle = stack.enter_context(stdout_path.open("wb")) if stdout_path is not None else None
+        subprocess.run(
+            command,
+            check=True,
+            stdin=stdin_handle,
+            stdout=stdout_handle,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="configs/lm/coral_train_only_v1.yaml")
+    parser.add_argument("--order", type=int, default=3)
+    parser.add_argument("--text-path", default=None)
+    parser.add_argument("--output-prefix", default=None)
+    parser.add_argument("--lmplz-bin", default="lmplz")
+    parser.add_argument("--build-binary-bin", default="build_binary")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_yaml_config(args.config)
+    default_text_path = resolve_project_path(config["output"]["corpus_text_path"])
+    text_path = resolve_project_path(args.text_path) if args.text_path else default_text_path
+
+    default_prefix = resolve_project_path(f"artifacts/lm/{config['name']}_{args.order}gram")
+    output_prefix = resolve_project_path(args.output_prefix) if args.output_prefix else default_prefix
+    output_prefix.parent.mkdir(parents=True, exist_ok=True)
+
+    arpa_path = output_prefix.with_suffix(".arpa")
+    binary_path = output_prefix.with_suffix(".bin")
+
+    run_kenlm_command([args.lmplz_bin, "-o", str(args.order)], stdin_path=text_path, stdout_path=arpa_path)
+    run_kenlm_command([args.build_binary_bin, str(arpa_path), str(binary_path)])
+
+    logger.info("Built KenLM artifacts: {} and {}", arpa_path, binary_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/danish_asr/lm.py
+++ b/src/danish_asr/lm.py
@@ -1,0 +1,457 @@
+"""Helpers for Danish LM corpus building and CTC + KenLM decoding."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from danish_asr.utils import configure_project_cache_environment, get_project_fairseq2_cache_dir, resolve_project_path
+
+try:
+    import pyarrow.parquet as pq
+
+    _PYARROW_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency in tests/CI
+    pq = None  # type: ignore[assignment]
+    _PYARROW_AVAILABLE = False
+
+from fairseq2.assets import get_asset_store
+from fairseq2.data.tokenizers import Tokenizer
+from fairseq2.data.tokenizers.char import load_char_tokenizer
+from fairseq2.data.tokenizers.hub import load_tokenizer
+from fairseq2.data.tokenizers.sentencepiece import load_sentencepiece_model
+from fairseq2.models.wav2vec2.asr import Wav2Vec2AsrModel, get_wav2vec2_asr_model_hub
+from loguru import logger
+from omnilingual_asr.models.inference.pipeline import ASRInferencePipeline
+
+LM_VERSION = "danish_lm_v1"
+DEFAULT_CORPORA = ("coral_v3_read_aloud", "coral_v3_conversation")
+DEFAULT_LANGUAGE = "dan_Latn"
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_URL_RE = re.compile(r"https?://\S+|www\.\S+", re.IGNORECASE)
+_METADATA_TOKEN_RE = re.compile(
+    r"\b(?:speaker_id|speaker|spk|id|uid|utt|segment|timestamp)\b(?:\s*[:=_-]\s*[\w-]+)?",
+    re.IGNORECASE,
+)
+_ONLY_PUNCT_RE = re.compile(r"^[\W_]+$")
+
+
+@dataclass
+class CorpusStats:
+    """Compact statistics for an LM text build."""
+
+    version: str
+    split: str
+    language: str
+    corpora: list[str]
+    raw_examples: int
+    written_examples: int
+    unique_examples: int
+    token_count: int
+    source_counts: dict[str, int]
+    normalization: dict[str, Any]
+
+
+@dataclass
+class DecodeResult:
+    """Decoded hypothesis with reference metadata."""
+
+    prediction: str
+    reference: str
+    corpus: str
+    file: str
+    row_index: int
+
+
+def _require_pyarrow() -> None:
+    if not _PYARROW_AVAILABLE:
+        msg = "pyarrow is required for parquet-backed LM corpus and decoding scripts. Install the 'omni' dependency group."
+        raise ImportError(msg)
+
+
+def normalize_lm_text(text: str) -> str:
+    """Normalize transcript text for LM training without changing Danish orthography."""
+    text = unicodedata.normalize("NFKC", text)
+    text = _URL_RE.sub(" ", text)
+    text = _METADATA_TOKEN_RE.sub(" ", text)
+    text = text.lower()
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+
+    if not text or _ONLY_PUNCT_RE.fullmatch(text):
+        return ""
+
+    return text
+
+
+def parse_valid_split(valid_split: str) -> tuple[str, str | None]:
+    """Parse fairseq2 split names such as ``test`` or ``test_coral_v3_read_aloud``."""
+    if valid_split in {"train", "dev", "test"}:
+        return valid_split, None
+
+    split, _, corpus = valid_split.partition("_")
+    if split not in {"train", "dev", "test"} or not corpus:
+        msg = f"Unsupported valid_split value: {valid_split}"
+        raise ValueError(msg)
+
+    return split, corpus
+
+
+def iter_fairseq2_rows(
+    dataset_root: Path,
+    *,
+    split: str,
+    language: str = DEFAULT_LANGUAGE,
+    corpora: Sequence[str] | None = None,
+    columns: Sequence[str] = ("text",),
+) -> Iterator[dict[str, Any]]:
+    """Yield rows from fairseq2 parquet shards for the requested corpora/split."""
+    _require_pyarrow()
+
+    root = resolve_project_path(dataset_root)
+    selected_corpora = (
+        list(corpora)
+        if corpora is not None
+        else sorted(path.name.removeprefix("corpus=") for path in root.glob("corpus=*") if path.is_dir())
+    )
+
+    for corpus in selected_corpora:
+        corpus_dir = root / f"corpus={corpus}" / f"split={split}" / f"language={language}"
+        if not corpus_dir.exists():
+            logger.warning(f"Skipping missing corpus split directory: {corpus_dir}")
+            continue
+
+        for parquet_file in sorted(corpus_dir.glob("*.parquet")):
+            parquet = pq.ParquetFile(parquet_file)
+            row_offset = 0
+            for batch in parquet.iter_batches(columns=list(columns)):
+                data = batch.to_pydict()
+                batch_size = len(next(iter(data.values()))) if data else 0
+                for idx in range(batch_size):
+                    row = {column: data[column][idx] for column in columns}
+                    row["corpus"] = corpus
+                    row["file"] = str(parquet_file)
+                    row["row_index"] = row_offset + idx
+                    yield row
+                row_offset += batch_size
+
+
+def build_lm_corpus_from_parquet(
+    dataset_root: Path,
+    *,
+    split: str = "train",
+    language: str = DEFAULT_LANGUAGE,
+    corpora: Sequence[str] = DEFAULT_CORPORA,
+) -> tuple[list[str], CorpusStats]:
+    """Build a deterministic LM text corpus from fairseq2 parquet transcripts."""
+    seen: set[str] = set()
+    lines: list[str] = []
+    source_counts = dict.fromkeys(corpora, 0)
+    raw_examples = 0
+    written_examples = 0
+    token_count = 0
+
+    for row in iter_fairseq2_rows(dataset_root, split=split, language=language, corpora=corpora, columns=("text",)):
+        raw_examples += 1
+        normalized = normalize_lm_text(str(row["text"]))
+        if not normalized:
+            continue
+
+        if normalized in seen:
+            continue
+
+        seen.add(normalized)
+        lines.append(normalized)
+        written_examples += 1
+        token_count += len(normalized.split())
+        source_counts[row["corpus"]] = source_counts.get(row["corpus"], 0) + 1
+
+    stats = CorpusStats(
+        version=LM_VERSION,
+        split=split,
+        language=language,
+        corpora=list(corpora),
+        raw_examples=raw_examples,
+        written_examples=written_examples,
+        unique_examples=len(lines),
+        token_count=token_count,
+        source_counts=source_counts,
+        normalization={
+            "unicode_normalization": "NFKC",
+            "lowercase": True,
+            "collapse_whitespace": True,
+            "strip_urls": True,
+            "strip_metadata_tokens": True,
+            "deduplicate_exact_lines": True,
+        },
+    )
+    return lines, stats
+
+
+def write_lm_corpus(texts: Iterable[str], output_path: Path) -> None:
+    """Write normalized LM text, one line per example."""
+    output_path = resolve_project_path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("".join(f"{line}\n" for line in texts), encoding="utf-8")
+
+
+def write_corpus_stats(stats: CorpusStats, output_path: Path) -> None:
+    """Write corpus stats as pretty JSON."""
+    output_path = resolve_project_path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(asdict(stats), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def load_yaml_config(path: str | Path) -> dict[str, Any]:
+    """Load a small YAML config file."""
+    import yaml
+
+    config_path = resolve_project_path(path)
+    with config_path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _get_cached_tokenizer_path(tokenizer_name: str) -> Path | None:
+    """Find a cached tokenizer model file using the asset card basename."""
+    store = get_asset_store()
+    card = store.retrieve_card(tokenizer_name)
+    tokenizer_uri = card.field("tokenizer").as_uri()
+    model_name = Path(tokenizer_uri.path).name
+
+    candidate_roots = [
+        get_project_fairseq2_cache_dir() / "assets",
+        Path.home() / ".cache" / "fairseq2" / "assets",
+    ]
+
+    for root in candidate_roots:
+        if not root.exists():
+            continue
+
+        matches = sorted(root.glob(f"*/{model_name}"))
+        if matches:
+            return matches[0]
+
+    return None
+
+
+def load_omniasr_tokenizer(
+    tokenizer_name: str,
+    *,
+    tokenizer_model_path: str | Path | None = None,
+) -> tuple[Tokenizer, Path]:
+    """Load the OmniASR tokenizer, preferring an explicit or cached local model file."""
+    configure_project_cache_environment()
+
+    if tokenizer_model_path is not None:
+        tokenizer_path = resolve_project_path(tokenizer_model_path)
+        return load_char_tokenizer(tokenizer_path, None), tokenizer_path
+
+    cached_path = _get_cached_tokenizer_path(tokenizer_name)
+    if cached_path is not None:
+        return load_char_tokenizer(cached_path, None), cached_path
+
+    tokenizer = load_tokenizer(tokenizer_name)
+    cached_path = _get_cached_tokenizer_path(tokenizer_name)
+    if cached_path is None:
+        msg = (
+            f"Tokenizer {tokenizer_name} loaded but a local tokenizer model path could not be resolved. "
+            "Pass --tokenizer-model-path explicitly."
+        )
+        raise FileNotFoundError(msg)
+
+    return tokenizer, cached_path
+
+
+def build_pyctcdecode_labels(tokenizer_model_path: Path) -> tuple[list[str], set[str]]:
+    """Build pyctcdecode labels in the exact OmniASR logit order."""
+    model = load_sentencepiece_model(tokenizer_model_path)
+    labels: list[str] = []
+    removable_tokens: set[str] = set()
+
+    for idx in range(model.vocabulary_size):
+        token = model.index_to_token(idx)
+
+        if idx == 0:
+            labels.append("")
+            continue
+
+        labels.append(token)
+
+        if token in {"<pad>", "</s>", "<s>"}:
+            removable_tokens.add(token)
+
+    return labels, removable_tokens
+
+
+def strip_special_tokens(text: str, removable_tokens: set[str]) -> str:
+    """Remove special-token text artifacts after beam decoding."""
+    cleaned = text
+    for token in removable_tokens:
+        cleaned = cleaned.replace(token, "")
+
+    return _WHITESPACE_RE.sub(" ", cleaned).strip()
+
+
+def load_custom_omniasr_ctc_model(
+    checkpoint_path: str | Path,
+    *,
+    model_arch: str,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Wav2Vec2AsrModel:
+    """Load a custom OmniASR CTC checkpoint using fairseq2's registered family."""
+    configure_project_cache_environment()
+
+    hub = get_wav2vec2_asr_model_hub()
+    config = hub.get_arch_config(model_arch)
+    return hub.load_custom_model(
+        resolve_project_path(checkpoint_path),
+        config,
+        device=device,
+        dtype=dtype,
+        progress=True,
+    )
+
+
+def make_inference_pipeline(
+    *,
+    checkpoint_path: str | Path,
+    model_arch: str,
+    tokenizer_name: str,
+    tokenizer_model_path: str | Path | None,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[ASRInferencePipeline, Path]:
+    """Create an OmniASR inference pipeline for CTC decoding."""
+    model = load_custom_omniasr_ctc_model(checkpoint_path, model_arch=model_arch, device=device, dtype=dtype)
+    tokenizer, resolved_tokenizer_path = load_omniasr_tokenizer(
+        tokenizer_name,
+        tokenizer_model_path=tokenizer_model_path,
+    )
+
+    pipeline = ASRInferencePipeline(
+        model_card=None,
+        model=model,
+        tokenizer=tokenizer,
+        device=device,
+        dtype=dtype,
+    )
+    return pipeline, resolved_tokenizer_path
+
+
+def chunked(items: Sequence[Any], size: int) -> Iterator[Sequence[Any]]:
+    """Yield fixed-size chunks from a sequence."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def read_text_lines(path: str | Path) -> list[str]:
+    """Read UTF-8 text lines without trailing newlines."""
+    return resolve_project_path(path).read_text(encoding="utf-8").splitlines()
+
+
+def write_text_lines(path: str | Path, lines: Iterable[str]) -> None:
+    """Write UTF-8 text lines with trailing newlines."""
+    output_path = resolve_project_path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("".join(f"{line}\n" for line in lines), encoding="utf-8")
+
+
+def infer_split_from_eval_config(config_path: str | Path) -> dict[str, Any]:
+    """Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval config."""
+    config = load_yaml_config(config_path)
+
+    model_cfg = config["model"]
+    dataset_cfg = config["dataset"]
+    tokenizer_cfg = config["tokenizer"]
+
+    summary_path = resolve_project_path(dataset_cfg["mixture_parquet_storage_config"]["dataset_summary_path"])
+
+    return {
+        "checkpoint_path": Path(model_cfg["path"]),
+        "model_arch": model_cfg["arch"],
+        "tokenizer_name": tokenizer_cfg["name"],
+        "dataset_root": summary_path.parent,
+        "valid_split": dataset_cfg["valid_split"],
+    }
+
+
+def make_decoder_factory(
+    labels: Sequence[str],
+    *,
+    kenlm_model_path: str | Path | None,
+    alpha: float,
+    beta: float,
+) -> Any:
+    """Construct a pyctcdecode decoder lazily."""
+    try:
+        from pyctcdecode import build_ctcdecoder
+    except ImportError as ex:  # pragma: no cover - optional dependency in CI
+        msg = "pyctcdecode is required for beam decoding. Install it before using --decoder beam."
+        raise ImportError(msg) from ex
+
+    decoder_kwargs: dict[str, Any] = {
+        "labels": list(labels),
+        "alpha": alpha,
+        "beta": beta,
+    }
+    if kenlm_model_path is not None:
+        decoder_kwargs["kenlm_model_path"] = str(resolve_project_path(kenlm_model_path))
+
+    return build_ctcdecoder(**decoder_kwargs)
+
+
+def score_predictions(predictions: Sequence[str], references: Sequence[str]) -> dict[str, Any]:
+    """Compute simple WER summary from aligned prediction/reference lists."""
+    if len(predictions) != len(references):
+        msg = "Predictions and references must have the same number of lines."
+        raise ValueError(msg)
+
+    from jiwer import wer
+
+    score = wer(list(references), list(predictions))
+    return {
+        "num_examples": len(predictions),
+        "wer": score * 100.0,
+    }
+
+
+def resolve_dtype(dtype_name: str, device: torch.device) -> torch.dtype:
+    """Resolve a dtype string with a CPU-safe fallback."""
+    dtype_map = {
+        "float32": torch.float32,
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+    }
+    dtype = dtype_map[dtype_name]
+    if device.type == "cpu" and dtype != torch.float32:
+        logger.warning(f"Falling back to float32 on CPU instead of requested {dtype_name}.")
+        return torch.float32
+    return dtype
+
+
+def collate_decode_records(records: Sequence[DecodeResult]) -> tuple[list[str], list[str]]:
+    """Split decode records into aligned prediction and reference lists."""
+    return [record.prediction for record in records], [record.reference for record in records]
+
+
+def decode_logits_with_argmax(
+    logits: torch.Tensor,
+    *,
+    seq_len: int,
+    token_decoder: Callable[[torch.Tensor], str],
+) -> str:
+    """Apply greedy CTC decoding to a single logit sequence."""
+    pred_ids = torch.argmax(logits[:seq_len], dim=-1)
+    mask = torch.ones(pred_ids.shape[0], dtype=torch.bool, device=pred_ids.device)
+    if pred_ids.shape[0] > 1:
+        mask[1:] = pred_ids[1:] != pred_ids[:-1]
+
+    return _WHITESPACE_RE.sub(" ", token_decoder(pred_ids[mask])).strip()

--- a/src/danish_asr/utils.py
+++ b/src/danish_asr/utils.py
@@ -28,6 +28,11 @@ def get_project_hf_cache_dir() -> Path:
     return _PROJECT_ROOT / ".cache" / "huggingface"
 
 
+def get_project_fairseq2_cache_dir() -> Path:
+    """Return the project-local fairseq2 cache directory."""
+    return _PROJECT_ROOT / ".cache" / "fairseq2"
+
+
 def configure_project_cache_environment() -> None:
     """Pin model and dataset caches to the project drive.
 
@@ -38,8 +43,11 @@ def configure_project_cache_environment() -> None:
     hub_cache = hf_home / "hub"
     datasets_cache = hf_home / "datasets"
     torch_home = _PROJECT_ROOT / ".cache" / "torch"
+    fairseq2_cache = get_project_fairseq2_cache_dir()
+    fairseq2_assets = fairseq2_cache / "assets"
+    tmp_dir = _PROJECT_ROOT / ".cache" / "tmp"
 
-    for directory in (hf_home, hub_cache, datasets_cache, torch_home):
+    for directory in (hf_home, hub_cache, datasets_cache, torch_home, fairseq2_cache, fairseq2_assets, tmp_dir):
         directory.mkdir(parents=True, exist_ok=True)
 
     os.environ["HF_HOME"] = str(hf_home)
@@ -47,6 +55,8 @@ def configure_project_cache_environment() -> None:
     os.environ["HUGGINGFACE_HUB_CACHE"] = str(hub_cache)
     os.environ["TRANSFORMERS_CACHE"] = str(hub_cache)
     os.environ["TORCH_HOME"] = str(torch_home)
+    os.environ["FAIRSEQ2_CACHE_DIR"] = str(fairseq2_cache)
+    os.environ["TMPDIR"] = str(tmp_dir)
 
 
 def get_device() -> torch.device:

--- a/tests/test_lm.py
+++ b/tests/test_lm.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pyarrow", reason="pyarrow not installed (omni group); skipping LM parquet tests")
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+
+from danish_asr.lm import (
+    build_lm_corpus_from_parquet,
+    decode_logits_with_argmax,
+    normalize_lm_text,
+    parse_valid_split,
+    score_predictions,
+    strip_special_tokens,
+)
+from scripts.lm.build_kenlm import run_kenlm_command
+
+
+def _write_fairseq2_split(base: Path, corpus: str, split: str, texts: list[str]) -> None:
+    split_dir = base / f"corpus={corpus}" / f"split={split}" / "language=dan_Latn"
+    split_dir.mkdir(parents=True, exist_ok=True)
+    table = pa.table(
+        {
+            "text": texts,
+            "audio_bytes": [b"flac"] * len(texts),
+            "audio_size": [16000] * len(texts),
+        }
+    )
+    pq.write_table(table, split_dir / "part-00000.parquet")
+
+
+def test_normalize_lm_text_lowercases_and_strips_urls_and_metadata() -> None:
+    assert normalize_lm_text("Speaker_ID=abc123 HEJ https://example.com") == "hej"
+
+
+def test_parse_valid_split_handles_combined_and_subset() -> None:
+    assert parse_valid_split("test") == ("test", None)
+    assert parse_valid_split("test_coral_v3_read_aloud") == ("test", "coral_v3_read_aloud")
+
+
+def test_build_lm_corpus_from_parquet_uses_train_only_and_deduplicates(tmp_path: Path) -> None:
+    _write_fairseq2_split(tmp_path, "coral_v3_read_aloud", "train", ["Hej verden", "Hej verden"])
+    _write_fairseq2_split(tmp_path, "coral_v3_conversation", "train", ["URL https://example.com test"])
+    _write_fairseq2_split(tmp_path, "coral_v3_read_aloud", "dev", ["should not appear"])
+    _write_fairseq2_split(tmp_path, "coral_v3_conversation", "test", ["should not appear"])
+
+    texts, stats = build_lm_corpus_from_parquet(tmp_path)
+
+    assert texts == ["hej verden", "url test"]
+    assert stats.raw_examples == 3
+    assert stats.unique_examples == 2
+    assert stats.source_counts["coral_v3_read_aloud"] == 1
+    assert stats.source_counts["coral_v3_conversation"] == 1
+
+
+def test_run_kenlm_command_redirects_stdin_and_stdout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(command: list[str], check: bool, stdin, stdout) -> None:
+        seen["command"] = command
+        seen["stdin_name"] = None if stdin is None else Path(stdin.name).name
+        seen["stdout_name"] = None if stdout is None else Path(stdout.name).name
+        assert check is True
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    stdin_path = tmp_path / "input.txt"
+    stdout_path = tmp_path / "output.arpa"
+    stdin_path.write_text("hej\n", encoding="utf-8")
+
+    run_kenlm_command(["lmplz", "-o", "3"], stdin_path=stdin_path, stdout_path=stdout_path)
+
+    assert seen["command"] == ["lmplz", "-o", "3"]
+    assert seen["stdin_name"] == "input.txt"
+    assert seen["stdout_name"] == "output.arpa"
+
+
+def test_decode_logits_with_argmax_collapses_repeats() -> None:
+    logits = torch.tensor(
+        [
+            [5.0, 0.0, 0.0],
+            [5.0, 0.0, 0.0],
+            [0.0, 6.0, 0.0],
+            [0.0, 0.0, 7.0],
+            [0.0, 0.0, 7.0],
+        ]
+    )
+
+    def token_decoder(indices: torch.Tensor) -> str:
+        mapping = {0: "", 1: "a", 2: "b"}
+        return "".join(mapping[int(idx)] for idx in indices)
+
+    assert decode_logits_with_argmax(logits, seq_len=5, token_decoder=token_decoder) == "ab"
+
+
+def test_strip_special_tokens_removes_known_artifacts() -> None:
+    assert strip_special_tokens("<s> hej </s> <pad>", {"<s>", "</s>", "<pad>"}) == "hej"
+
+
+def test_score_predictions_returns_percent_wer() -> None:
+    summary = score_predictions(["hej verden"], ["hej verden"])
+    assert summary["num_examples"] == 1
+    assert summary["wer"] == 0.0

--- a/uv.lock
+++ b/uv.lock
@@ -689,6 +689,7 @@ dependencies = [
     { name = "numpy" },
     { name = "omegaconf" },
     { name = "peft" },
+    { name = "pyctcdecode" },
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -739,6 +740,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "peft", specifier = ">=0.10.0" },
+    { name = "pyctcdecode", specifier = ">=0.5.0" },
     { name = "pytorch-lightning", specifier = ">=2.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -1602,6 +1604,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.151.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ab/67ca321d1ab96fd3828b12142f1c258e2d4a668a025d06cd50ab3409787f/hypothesis-6.151.12.tar.gz", hash = "sha256:be485f503979af4c3dfa19e3fc2b967d0458e7f8c4e28128d7e215e0a55102e0", size = 463900, upload-time = "2026-04-08T19:40:06.205Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/5a/6cecf134b631050a1f8605096adbe812483b60790d951470989d39b56860/hypothesis-6.151.12-py3-none-any.whl", hash = "sha256:37d4f3a768365c30571b11dfd7a6857a12173d933010b2c4ab65619f1b5952c5", size = 529656, upload-time = "2026-04-08T19:40:03.126Z" },
 ]
 
 [[package]]
@@ -3160,6 +3174,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyctcdecode"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hypothesis" },
+    { name = "numpy" },
+    { name = "pygtrie" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/96/7dec2cb5414c388b94044f25d701ed9d08e30ba2509a4e2cf6451cdd25ed/pyctcdecode-0.5.0.tar.gz", hash = "sha256:f3bcb313e43ca16a54938b3e77b0b375328653bba932668243db745fde513a2c", size = 68451, upload-time = "2023-01-20T21:11:00.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/8a/93e2118411ae5e861d4f4ce65578c62e85d0f1d9cb389bd63bd57130604e/pyctcdecode-0.5.0-py2.py3-none-any.whl", hash = "sha256:5b4282872ddc8e30fe7ac45112f4ab6134ac67fc03df0bbecf48667d032a0914", size = 39166, upload-time = "2023-01-20T21:10:58.808Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4147,9 +4175,9 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:a47b7986bee3f61ad217d8a8ce24605809ab425baf349f97de758815edd2ef54" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:fbe2e149c5174ef90d29a5f84a554dfaf28e003cb4f61fa2c8c024c17ec7ca58" },
-    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:057efd30a6778d2ee5e2374cd63a63f63311aa6f33321e627c655df60abdd390" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:a47b7986bee3f61ad217d8a8ce24605809ab425baf349f97de758815edd2ef54" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:fbe2e149c5174ef90d29a5f84a554dfaf28e003cb4f61fa2c8c024c17ec7ca58" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:057efd30a6778d2ee5e2374cd63a63f63311aa6f33321e627c655df60abdd390" },
 ]
 
 [[package]]
@@ -4226,12 +4254,12 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4354fc05bb79b208d6995a04ca1ceef6a9547b1c4334435574353d381c55087c" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:0ad925202387f4e7314302a1b4f8860fa824357f9b1466d7992bf276370ebcff" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3a852369a38dec343d45ecd0bc3660f79b88a23e0c878d18707f7c13bf49538f" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:9e20646802b7fc295c1f8b45fefcfc9fb2e4ec9cbe8593443cd2b9cc307c8405" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4295a22d69408e93d25f51e8d5d579345b6b802383e9414b0f3853ed433d53ae" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:970b4f4661fa7b44f6a7e6df65de7fc4a6fff2af610dc415c1d695ca5f1f37d2" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4354fc05bb79b208d6995a04ca1ceef6a9547b1c4334435574353d381c55087c" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:0ad925202387f4e7314302a1b4f8860fa824357f9b1466d7992bf276370ebcff" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3a852369a38dec343d45ecd0bc3660f79b88a23e0c878d18707f7c13bf49538f" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:9e20646802b7fc295c1f8b45fefcfc9fb2e4ec9cbe8593443cd2b9cc307c8405" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4295a22d69408e93d25f51e8d5d579345b6b802383e9414b0f3853ed433d53ae" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:970b4f4661fa7b44f6a7e6df65de7fc4a6fff2af610dc415c1d695ca5f1f37d2" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add the first standalone KenLM decoding pipeline for OmniASR CTC evaluation.

This PR introduces a minimal iteration-1 path to test whether LM-backed CTC decoding improves the current best Danish checkpoint (`omniASR_CTC_3B_v2` finetuned on CoRal v3), without changing the existing fairseq2 evaluation wrapper.

## What Changed

- added reusable LM helpers in `src/danish_asr/lm.py`
- added cache setup for `FAIRSEQ2_CACHE_DIR` and `TMPDIR` in `src/danish_asr/utils.py`
- added LM corpus configs for local and HPC runs
- added `scripts/lm/build_danish_lm_corpus.py` to build `danish_lm_v1` from CoRal train transcripts only
- added `scripts/lm/build_kenlm.py` to build `.arpa` and `.bin` KenLM artifacts
- added `scripts/decode_ctc_with_lm.py` for standalone greedy or `pyctcdecode` beam decoding from an OmniASR checkpoint
- added `scripts/evaluate_ctc_predictions.py` to score saved predictions and references
- added `scripts/hpc/decode_with_lm.sh` to run the 3B combined decoding grid on HPC
- documented the LM-decoding result table template in `docs/evaluation-results.md`
- added `pyctcdecode` to project dependencies and refreshed `uv.lock`
- added focused tests in `tests/test_lm.py`

## Why

The current repo has strong greedy CTC baselines, but no clean way to test whether external LM decoding improves Danish ASR quality. This PR adds the smallest reproducible path to answer that question while keeping the existing fairseq2 eval flow unchanged for baseline comparison.

## Validation

- `./.venv/bin/python -m py_compile src/danish_asr/lm.py scripts/decode_ctc_with_lm.py scripts/evaluate_ctc_predictions.py scripts/lm/build_danish_lm_corpus.py scripts/lm/build_kenlm.py tests/test_lm.py`
- `bash -n scripts/hpc/decode_with_lm.sh`
- `uv run pytest tests/test_lm.py`
- `uv run pytest tests/test_lm.py tests/test_hpc_run_eval.py`

## Notes

- The actual 3B LM-decoding experiment has not been run yet in this PR; this change adds the pipeline and HPC submission path for that experiment.
- The first LM corpus intentionally uses `CoRal v3` train transcripts only to minimize setup complexity and avoid evaluation leakage.
- Unrelated local changes in `docs/index.md` and `docs/7b-feasibility.md` were intentionally left out of this PR.