### PR TITLE
Add LLM V2 finetuning configs and HPC training scripts

### DIFF
--- a/configs/fairseq2/llm_1b/llm-finetune-hpc-e1-1b.yaml
+++ b/configs/fairseq2/llm_1b/llm-finetune-hpc-e1-1b.yaml
@@ -1,0 +1,61 @@
+# E1 LLM V2 training: omniASR_LLM_1B_v2 on CoRal-v3 Danish.
+# Effective params: 2.3B (1B encoder + 1.3B Llama decoder).
+# Requires A100-80GB (see HPC script: select[gpu80gb]).
+# grad_accumulation=16 preserves effective batch relative to 300M track.
+
+model:
+  name: "omniASR_LLM_1B_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  train_split: "train"
+  valid_split: "dev"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 240_000
+    max_num_elements: 1_920_000
+    batch_shuffle_window: 1000
+    normalize_audio: true
+    example_shuffle_window: 1000
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+optimizer:
+  config:
+    lr: 5e-5
+
+lr_scheduler:
+  name: "tri_stage"
+  config:
+    stage_ratio: [0.1, 0.0, 0.9]
+    start_lr_scale: 0.01
+    final_lr_scale: 0.05
+
+gang:
+  timeout: 259200
+
+trainer:
+  freeze_encoder_for_n_steps: 0
+  mixed_precision:
+    dtype: "torch.bfloat16"
+  grad_accumulation:
+    num_batches: 16
+
+regime:
+  num_steps: 20_000
+  validate_after_n_steps: 500
+  validate_every_n_steps: 1000
+  checkpoint_every_n_steps: 1000
+  save_model_only: "all_but_last"
+  keep_last_n_checkpoints: 2
+  keep_best_n_checkpoints: 1
+  publish_metrics_every_n_steps: 100

--- a/configs/fairseq2/llm_1b/llm-finetune-smoke.yaml
+++ b/configs/fairseq2/llm_1b/llm-finetune-smoke.yaml
@@ -1,0 +1,49 @@
+# 50-step smoke test for omniASR_LLM_1B_v2.
+# Run after pulling the 1B checkpoint (invoke assets.pull-llm --size 1b)
+# and before submitting the full training job.
+
+model:
+  name: "omniASR_LLM_1B_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  train_split: "train"
+  valid_split: "dev"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 240_000
+    max_num_elements: 1_920_000
+    batch_shuffle_window: 1
+    normalize_audio: true
+    example_shuffle_window: 1
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+optimizer:
+  config:
+    lr: 5e-5
+
+trainer:
+  freeze_encoder_for_n_steps: 0
+  mixed_precision:
+    dtype: "torch.bfloat16"
+  grad_accumulation:
+    num_batches: 16
+
+regime:
+  num_steps: 50
+  validate_after_n_steps: 25
+  validate_every_n_steps: 25
+  checkpoint_every_n_steps: 50
+  keep_last_n_checkpoints: 1
+  keep_best_n_checkpoints: 1
+  publish_metrics_every_n_steps: 10

--- a/configs/fairseq2/llm_300m/llm-finetune-hpc-e1.yaml
+++ b/configs/fairseq2/llm_300m/llm-finetune-hpc-e1.yaml
@@ -1,0 +1,61 @@
+# E1 LLM V2 training: omniASR_LLM_300M_v2 on CoRal-v3 Danish.
+# LLM decoder activation memory scales O(seq²), so max_audio_len is capped at
+# 240k (15s) rather than the CTC standard of 960k (60s).
+# Targets a single A100-40GB with grad_accumulation=8.
+
+model:
+  name: "omniASR_LLM_300M_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  train_split: "train"
+  valid_split: "dev"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 240_000
+    max_num_elements: 2_560_000
+    batch_shuffle_window: 1000
+    normalize_audio: true
+    example_shuffle_window: 1000
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+optimizer:
+  config:
+    lr: 5e-5
+
+lr_scheduler:
+  name: "tri_stage"
+  config:
+    stage_ratio: [0.1, 0.0, 0.9]
+    start_lr_scale: 0.01
+    final_lr_scale: 0.05
+
+gang:
+  timeout: 259200
+
+trainer:
+  freeze_encoder_for_n_steps: 0
+  mixed_precision:
+    dtype: "torch.bfloat16"
+  grad_accumulation:
+    num_batches: 8
+
+regime:
+  num_steps: 20_000
+  validate_after_n_steps: 500
+  validate_every_n_steps: 1000
+  checkpoint_every_n_steps: 1000
+  save_model_only: "all_but_last"
+  keep_last_n_checkpoints: 2
+  keep_best_n_checkpoints: 1
+  publish_metrics_every_n_steps: 100

--- a/configs/fairseq2/llm_300m/llm-finetune-smoke.yaml
+++ b/configs/fairseq2/llm_300m/llm-finetune-smoke.yaml
@@ -1,0 +1,49 @@
+# 50-step smoke test for omniASR_LLM_300M_v2.
+# Validates that the full pipeline (model load, data, forward, checkpoint) runs
+# end-to-end on HPC A100-40GB before committing to a full training run.
+
+model:
+  name: "omniASR_LLM_300M_v2"
+
+dataset:
+  name: "coral_v3_danish"
+  train_split: "train"
+  valid_split: "dev"
+  storage_mode: "MIXTURE_PARQUET"
+  task_mode: "ASR"
+  mixture_parquet_storage_config:
+    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    beta_corpus: 0.5
+    beta_language: 0.5
+    fragment_loading:
+      cache: true
+  asr_task_config:
+    min_audio_len: 32_000
+    max_audio_len: 240_000
+    max_num_elements: 2_560_000
+    batch_shuffle_window: 1
+    normalize_audio: true
+    example_shuffle_window: 1
+
+tokenizer:
+  name: "omniASR_tokenizer_written_v2"
+
+optimizer:
+  config:
+    lr: 5e-5
+
+trainer:
+  freeze_encoder_for_n_steps: 0
+  mixed_precision:
+    dtype: "torch.bfloat16"
+  grad_accumulation:
+    num_batches: 8
+
+regime:
+  num_steps: 50
+  validate_after_n_steps: 25
+  validate_every_n_steps: 25
+  checkpoint_every_n_steps: 50
+  keep_last_n_checkpoints: 1
+  keep_best_n_checkpoints: 1
+  publish_metrics_every_n_steps: 10

--- a/docs/dtu-hpc-reference.md
+++ b/docs/dtu-hpc-reference.md
@@ -101,16 +101,18 @@ Account expiry = immediate data loss. `/work3` is not backed up. Export importan
 
 ## GPU Queues
 
-All GPU queues: 24h max walltime. Default walltime if omitted: **15 minutes**.
+Default walltime if omitted: **15 minutes**. Verified via `bqueues -l gpua100`,
+the `gpua100` queue allows up to 72 hours. Keep other GPU queues at 24 hours
+unless you verify a different limit directly.
 
-| Queue | GPU | Nodes | GPUs/node | VRAM |
-|-------|-----|-------|-----------|------|
-| `gpua100` | A100 PCIe | 4+6 | 2 | 40 GB / 80 GB |
-| `gpul40s` | L40s PCIe | 6 | 2 | 48 GB |
-| `gpuv100` | V100 PCIe | 6+8 | 2 | 16 GB / 32 GB |
-| `gpuv100` | V100 NVLink SXM2 | 3 | 4 | 32 GB |
-| `gpua10` | A10 PCIe | 1 | 2 | 24 GB |
-| `gpua40` | A40 NVLink | 1 | 2 | 48 GB |
+| Queue | GPU | Nodes | GPUs/node | VRAM | Max walltime |
+|-------|-----|-------|-----------|------|--------------|
+| `gpua100` | A100 PCIe | 4+6 | 2 | 40 GB / 80 GB | 72h |
+| `gpul40s` | L40s PCIe | 6 | 2 | 48 GB | 24h |
+| `gpuv100` | V100 PCIe | 6+8 | 2 | 16 GB / 32 GB | 24h |
+| `gpuv100` | V100 NVLink SXM2 | 3 | 4 | 32 GB | 24h |
+| `gpua10` | A10 PCIe | 1 | 2 | 24 GB | 24h |
+| `gpua40` | A40 NVLink | 1 | 2 | 48 GB | 24h |
 
 CPU queue `hpc`: 72h max, 100 cores/job.
 

--- a/docs/dtu_hpc/03-lsf-jobs.md
+++ b/docs/dtu_hpc/03-lsf-jobs.md
@@ -102,19 +102,23 @@ Default when omitted: `1024MB` per core.
 
 ## Queues and limits
 
-### GPU queues (all have 24h max walltime)
+### GPU queues
 
-| Queue | GPU | Nodes | GPUs/node | VRAM |
-|-------|-----|-------|-----------|------|
-| `gpua100` | A100 PCIe | 4 | 2 | 40 GB |
-| `gpua100` | A100 PCIe | 6 | 2 | 80 GB |
-| `gpul40s` | L40s PCIe | 6 | 2 | 48 GB |
-| `gpuv100` | V100 PCIe | 6 | 2 | 16 GB |
-| `gpuv100` | V100 PCIe | 8 | 2 | 32 GB |
-| `gpuv100` | V100 NVLink SXM2 | 3 | 4 | 32 GB |
-| `gpua10` | A10 PCIe | 1 | 2 | 24 GB |
-| `gpua40` | A40 NVLink | 1 | 2 | 48 GB |
-| `gpuamd` | AMD Radeon Instinct MI50 | 1 | 2 | 16 GB |
+Default walltime is still 15 minutes if `-W` is omitted. The `gpua100` queue
+allows up to 72 hours; keep other GPU queues at 24 hours unless you verify a
+different limit directly with `bqueues -l <queue>`.
+
+| Queue | GPU | Nodes | GPUs/node | VRAM | Max walltime |
+|-------|-----|-------|-----------|------|--------------|
+| `gpua100` | A100 PCIe | 4 | 2 | 40 GB | 72h |
+| `gpua100` | A100 PCIe | 6 | 2 | 80 GB | 72h |
+| `gpul40s` | L40s PCIe | 6 | 2 | 48 GB | 24h |
+| `gpuv100` | V100 PCIe | 6 | 2 | 16 GB | 24h |
+| `gpuv100` | V100 PCIe | 8 | 2 | 32 GB | 24h |
+| `gpuv100` | V100 NVLink SXM2 | 3 | 4 | 32 GB | 24h |
+| `gpua10` | A10 PCIe | 1 | 2 | 24 GB | 24h |
+| `gpua40` | A40 NVLink | 1 | 2 | 48 GB | 24h |
+| `gpuamd` | AMD Radeon Instinct MI50 | 1 | 2 | 16 GB | 24h |
 
 Retired (do not use): `gputitanxpascal`, `gpuk80`, `gpuk40`
 

--- a/docs/dtu_hpc/README.md
+++ b/docs/dtu_hpc/README.md
@@ -28,7 +28,7 @@ voltash                              # shared interactive V100 (16 GB)
 
 | Queue | GPU | VRAM | Max walltime |
 |-------|-----|------|-------------|
-| `gpua100` | A100 PCIe | 40 GB / 80 GB | 24h |
+| `gpua100` | A100 PCIe | 40 GB / 80 GB | 72h |
 | `gpul40s` | L40s PCIe | 48 GB | 24h |
 | `gpuv100` | V100 | 16 GB / 32 GB | 24h |
 

--- a/docs/finetuning-recipe.md
+++ b/docs/finetuning-recipe.md
@@ -131,6 +131,40 @@ regime:
 | `validate_every_n_steps` | 1,000 | 500 | 1,000 | More frequent on shorter runs |
 | `checkpoint_every_n_steps` | 1,000 | 500 | 1,000 | More frequent on shorter runs |
 
+## LLM V2 Finetuning (active track)
+
+The LLM V2 class (`omniASR_LLM_300M_v2`, `omniASR_LLM_1B_v2`) uses the same
+`python -m workflows.recipes.wav2vec2.asr` entrypoint and the same Parquet
+corpus as CTC, but the autoregressive Llama decoder introduces key differences:
+
+| Aspect | CTC V2 | LLM V2 |
+|---|---|---|
+| Loss | CTC alignment | Cross-entropy (teacher-forced causal LM) |
+| `max_audio_len` | 960,000 (60s) | **240,000 (15s)** — decoder activations scale O(seq²) |
+| Inference speed | ~96× real-time (RTF 0.001) | ~1× real-time (RTF 0.090) |
+| A100-40GB viable | Yes (all sizes) | 300M_v2 only; 1B_v2 needs 80GB |
+| Checkpoint size | ~1.3 GiB (300M) | **6.1 GiB (300M_v2), 8.5 GiB (1B_v2)** |
+
+### Pre-pull checkpoints before training
+
+Fairseq2 auto-downloads on first use, but LLM checkpoints are 6–8.5 GiB.
+Pre-pull on the login node to avoid burning compute-node GPU time on downloads:
+
+```bash
+# Login node only (not inside a bsub job)
+source scripts/hpc/env.sh   # sets FAIRSEQ2_CACHE_DIR → /work3/$USER/fairseq2_cache
+invoke assets.pull-llm --size 300m   # or --size 1b
+```
+
+### LLM V2 configs and HPC scripts
+
+| Size | Config | HPC smoke | HPC full run |
+|---|---|---|---|
+| 300M_v2 | `configs/fairseq2/llm_300m/llm-finetune-hpc-e1.yaml` | `scripts/hpc/llm_300m/05_smoke_test.sh` | `scripts/hpc/llm_300m/14_train_e1.sh` |
+| 1B_v2 | `configs/fairseq2/llm_1b/llm-finetune-hpc-e1-1b.yaml` | `scripts/hpc/llm_1b/05_smoke_test.sh` | `scripts/hpc/llm_1b/14_train_e1_1b.sh` |
+
+If OOM on 300M_v2 smoke: reduce `max_num_elements` from 2,560,000 to 1,920,000.
+
 ## Multi-GPU Training (DTU HPC)
 
 The upstream recipe is designed for distributed training:

--- a/docs/finetuning-recipe.md
+++ b/docs/finetuning-recipe.md
@@ -8,6 +8,7 @@ Guide for fine-tuning `omniASR_CTC_300M` on CoRal-v3 Danish data using the omnil
 2. `omnilingual-asr` package installed
 3. fairseq2 asset card created for dataset
 4. `language_distribution_0.tsv` stats file generated
+5. On DTU HPC: clone upstream once at `/work3/$USER/omnilingual-asr` so `setup_omniasr` can expose the `workflows` recipe modules
 
 ## Training Command
 
@@ -141,7 +142,7 @@ corpus as CTC, but the autoregressive Llama decoder introduces key differences:
 |---|---|---|
 | Loss | CTC alignment | Cross-entropy (teacher-forced causal LM) |
 | `max_audio_len` | 960,000 (60s) | **240,000 (15s)** — decoder activations scale O(seq²) |
-| Inference speed | ~96× real-time (RTF 0.001) | ~1× real-time (RTF 0.090) |
+| Inference speed | Faster non-autoregressive decoding | Slower autoregressive decoding; benchmark on target hardware |
 | A100-40GB viable | Yes (all sizes) | 300M_v2 only; 1B_v2 needs 80GB |
 | Checkpoint size | ~1.3 GiB (300M) | **6.1 GiB (300M_v2), 8.5 GiB (1B_v2)** |
 
@@ -153,6 +154,8 @@ Pre-pull on the login node to avoid burning compute-node GPU time on downloads:
 ```bash
 # Login node only (not inside a bsub job)
 source scripts/hpc/env.sh   # sets FAIRSEQ2_CACHE_DIR → /work3/$USER/fairseq2_cache
+# If the active env lacks omnilingual_asr, the invoke task falls back to:
+#   source scripts/hpc/env.sh && setup_omniasr
 invoke assets.pull-llm --size 300m   # or --size 1b
 ```
 

--- a/docs/omnilingual-asr-overview.md
+++ b/docs/omnilingual-asr-overview.md
@@ -107,11 +107,13 @@ For the CTC track: **ctc-finetune** — we start from the released checkpoint wi
 | **Finetune LLM checkpoint (1B)** | `configs/fairseq2/llm_1b/llm-finetune-hpc-e1-1b.yaml` | `omniASR_LLM_1B_v2` | A100-80GB, 20k steps |
 
 LLM V2 models use `omniASR_tokenizer_written_v2` (same as CTC V2) and the same
-Parquet corpus. Pre-pull checkpoints before submitting: `invoke assets.pull-llm --size 300m`.
+Parquet corpus. On DTU HPC, clone upstream once at `/work3/$USER/omnilingual-asr`
+so `setup_omniasr` can expose the training recipe modules. Pre-pull checkpoints
+before submitting: `invoke assets.pull-llm --size 300m`.
 
 ## Key Limitations
 
-- CTC models: max 40s audio (960,000 samples at 16kHz)
+- CTC models: max 60s audio (960,000 samples at 16kHz)
 - LLM models: decoder activation memory scales O(seq²); use `max_audio_len: 240_000` (15s) not 960k
 - No LoRA/PEFT support — fairseq2 does full fine-tuning
 - `Unlimited` variants do not support finetuning recipes

--- a/docs/omnilingual-asr-overview.md
+++ b/docs/omnilingual-asr-overview.md
@@ -90,18 +90,29 @@ print(transcriptions)
 
 ## Finetuning Strategy Options
 
-Two approaches for CTC finetuning:
+### CTC models
 
 | Strategy | Config | Starting point | Use case |
 |---|---|---|---|
 | **Finetune CTC checkpoint** | `ctc-finetune.yaml` | `omniASR_CTC_300M` | Continue from released model (recommended) |
 | **Train CTC from encoder** | `ctc-from-encoder.yaml` | `omniASR_W2V_300M` | New CTC head on pretrained encoder |
 
-For our project: **ctc-finetune** — we start from the released `omniASR_CTC_300M` checkpoint, which already has a trained CTC head.
+For the CTC track: **ctc-finetune** — we start from the released checkpoint with a trained CTC head.
+
+### LLM V2 models (active track)
+
+| Strategy | Config | Starting point | Use case |
+|---|---|---|---|
+| **Finetune LLM checkpoint (300M)** | `configs/fairseq2/llm_300m/llm-finetune-hpc-e1.yaml` | `omniASR_LLM_300M_v2` | A100-40GB, 20k steps |
+| **Finetune LLM checkpoint (1B)** | `configs/fairseq2/llm_1b/llm-finetune-hpc-e1-1b.yaml` | `omniASR_LLM_1B_v2` | A100-80GB, 20k steps |
+
+LLM V2 models use `omniASR_tokenizer_written_v2` (same as CTC V2) and the same
+Parquet corpus. Pre-pull checkpoints before submitting: `invoke assets.pull-llm --size 300m`.
 
 ## Key Limitations
 
 - CTC models: max 40s audio (960,000 samples at 16kHz)
+- LLM models: decoder activation memory scales O(seq²); use `max_audio_len: 240_000` (15s) not 960k
 - No LoRA/PEFT support — fairseq2 does full fine-tuning
 - `Unlimited` variants do not support finetuning recipes
 - Requires Parquet-format data (see [data-preparation.md](data-preparation.md))

--- a/scripts/hpc/llm_1b/05_smoke_test.sh
+++ b/scripts/hpc/llm_1b/05_smoke_test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#BSUB -J danish_asr_llm_1b_smoke
+#BSUB -q gpua100
+#BSUB -n 4
+#BSUB -R "rusage[mem=16GB]"
+#BSUB -R "span[hosts=1]"
+#BSUB -R "select[gpu80gb]"
+#BSUB -gpu "num=1:mode=exclusive_process"
+#BSUB -W 2:00
+#BSUB -B
+#BSUB -N
+#BSUB -u s204696@dtu.dk
+#BSUB -o /work3/s204696/logs/lsf/llm_1b_smoke_%J.out
+#BSUB -e /work3/s204696/logs/lsf/llm_1b_smoke_%J.err
+#
+# 50-step smoke test for omniASR_LLM_1B_v2 (2.3B effective params).
+# Requires A100-80GB: decoder activations + optimizer states exceed 40GB.
+#
+# Pre-requisites:
+#   invoke assets.pull-llm --size 1b
+#
+# Usage:
+#   bsub < scripts/hpc/llm_1b/05_smoke_test.sh
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+python scripts/hpc/run_training.py \
+    --config configs/fairseq2/llm_1b/llm-finetune-smoke.yaml \
+    --wandb-resume never \
+    --wandb-tags "smoke,hpc,a100,80gb,llm_1b_v2,50steps"

--- a/scripts/hpc/llm_1b/05_smoke_test.sh
+++ b/scripts/hpc/llm_1b/05_smoke_test.sh
@@ -9,9 +9,8 @@
 #BSUB -W 2:00
 #BSUB -B
 #BSUB -N
-#BSUB -u s204696@dtu.dk
-#BSUB -o /work3/s204696/logs/lsf/llm_1b_smoke_%J.out
-#BSUB -e /work3/s204696/logs/lsf/llm_1b_smoke_%J.err
+#BSUB -o /work3/%U/logs/lsf/llm_1b_smoke_%J.out
+#BSUB -e /work3/%U/logs/lsf/llm_1b_smoke_%J.err
 #
 # 50-step smoke test for omniASR_LLM_1B_v2 (2.3B effective params).
 # Requires A100-80GB: decoder activations + optimizer states exceed 40GB.

--- a/scripts/hpc/llm_1b/14_train_e1_1b.sh
+++ b/scripts/hpc/llm_1b/14_train_e1_1b.sh
@@ -9,9 +9,8 @@
 #BSUB -W 40:00
 #BSUB -B
 #BSUB -N
-#BSUB -u s204696@dtu.dk
-#BSUB -o /work3/s204696/logs/lsf/llm_1b_e1_%J.out
-#BSUB -e /work3/s204696/logs/lsf/llm_1b_e1_%J.err
+#BSUB -o /work3/%U/logs/lsf/llm_1b_e1_%J.out
+#BSUB -e /work3/%U/logs/lsf/llm_1b_e1_%J.err
 #
 # E1 full finetune: omniASR_LLM_1B_v2 on CoRal-v3 Danish, 20k steps.
 # Requires A100-80GB (2.3B total params + AdamW optimizer states + decoder

--- a/scripts/hpc/llm_1b/14_train_e1_1b.sh
+++ b/scripts/hpc/llm_1b/14_train_e1_1b.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#BSUB -J danish_asr_llm_1b_e1
+#BSUB -q gpua100
+#BSUB -n 4
+#BSUB -R "rusage[mem=16GB]"
+#BSUB -R "span[hosts=1]"
+#BSUB -R "select[gpu80gb]"
+#BSUB -gpu "num=1:mode=exclusive_process"
+#BSUB -W 40:00
+#BSUB -B
+#BSUB -N
+#BSUB -u s204696@dtu.dk
+#BSUB -o /work3/s204696/logs/lsf/llm_1b_e1_%J.out
+#BSUB -e /work3/s204696/logs/lsf/llm_1b_e1_%J.err
+#
+# E1 full finetune: omniASR_LLM_1B_v2 on CoRal-v3 Danish, 20k steps.
+# Requires A100-80GB (2.3B total params + AdamW optimizer states + decoder
+# activations exceed A100-40GB at max_audio_len=240k).
+#
+# Pre-requisites (run from login node before submitting):
+#   invoke assets.pull-llm --size 1b
+#   bsub < scripts/hpc/llm_1b/05_smoke_test.sh  # verify first
+#
+# Usage:
+#   bsub < scripts/hpc/llm_1b/14_train_e1_1b.sh
+#
+# Resume support: resubmitting this script will auto-resume from the latest
+# checkpoint if training is interrupted.
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+RUN_DIR="${RESUME_DIR:-/work3/$USER/outputs/omniasr_llm_1b_e1}"
+mkdir -p "$RUN_DIR"
+
+python scripts/hpc/run_training.py \
+    --config configs/fairseq2/llm_1b/llm-finetune-hpc-e1-1b.yaml \
+    --output-dir "$RUN_DIR" \
+    --wandb-tags "train,full,hpc,a100,80gb,llm_1b_v2,e1,20k,lr5e-5,shuffle1000" \
+    --wandb-resume allow

--- a/scripts/hpc/llm_300m/05_smoke_test.sh
+++ b/scripts/hpc/llm_300m/05_smoke_test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#BSUB -J danish_asr_llm_300m_smoke
+#BSUB -q gpua100
+#BSUB -n 4
+#BSUB -R "rusage[mem=16GB]"
+#BSUB -R "span[hosts=1]"
+#BSUB -gpu "num=1:mode=exclusive_process"
+#BSUB -W 2:00
+#BSUB -B
+#BSUB -N
+#BSUB -u s204696@dtu.dk
+#BSUB -o /work3/s204696/logs/lsf/llm_300m_smoke_%J.out
+#BSUB -e /work3/s204696/logs/lsf/llm_300m_smoke_%J.err
+#
+# 50-step smoke test for omniASR_LLM_300M_v2.
+# Validates model load, data pipeline, forward/backward, and checkpoint write
+# before committing to the full 20k-step training run.
+#
+# Pre-requisites:
+#   - Checkpoint pre-pulled: invoke assets.pull-llm --size 300m
+#   - Parquet data on work3: scripts/hpc/data/02_convert_fairseq2.sh
+#
+# Usage:
+#   bsub < scripts/hpc/llm_300m/05_smoke_test.sh
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+python scripts/hpc/run_training.py \
+    --config configs/fairseq2/llm_300m/llm-finetune-smoke.yaml \
+    --wandb-resume never \
+    --wandb-tags "smoke,hpc,a100,llm_300m_v2,50steps"

--- a/scripts/hpc/llm_300m/05_smoke_test.sh
+++ b/scripts/hpc/llm_300m/05_smoke_test.sh
@@ -8,9 +8,8 @@
 #BSUB -W 2:00
 #BSUB -B
 #BSUB -N
-#BSUB -u s204696@dtu.dk
-#BSUB -o /work3/s204696/logs/lsf/llm_300m_smoke_%J.out
-#BSUB -e /work3/s204696/logs/lsf/llm_300m_smoke_%J.err
+#BSUB -o /work3/%U/logs/lsf/llm_300m_smoke_%J.out
+#BSUB -e /work3/%U/logs/lsf/llm_300m_smoke_%J.err
 #
 # 50-step smoke test for omniASR_LLM_300M_v2.
 # Validates model load, data pipeline, forward/backward, and checkpoint write

--- a/scripts/hpc/llm_300m/14_train_e1.sh
+++ b/scripts/hpc/llm_300m/14_train_e1.sh
@@ -8,15 +8,14 @@
 #BSUB -W 24:00
 #BSUB -B
 #BSUB -N
-#BSUB -u s204696@dtu.dk
-#BSUB -o /work3/s204696/logs/lsf/llm_300m_e1_%J.out
-#BSUB -e /work3/s204696/logs/lsf/llm_300m_e1_%J.err
+#BSUB -o /work3/%U/logs/lsf/llm_300m_e1_%J.out
+#BSUB -e /work3/%U/logs/lsf/llm_300m_e1_%J.err
 #
 # E1 full finetune: omniASR_LLM_300M_v2 on CoRal-v3 Danish, 20k steps.
 # A100-40GB is sufficient for LLM_300M_v2 at max_audio_len=240k (15s).
 #
-# Timing estimate: LLM decoder is ~30x slower per step than CTC (~96x RTF
-# vs ~1x). Expect 18-22h for 20k steps. 24h walltime includes buffer.
+# Timing estimate: LLM training is substantially slower per step than CTC.
+# Expect roughly 18-22h for 20k steps on A100-40GB. 24h walltime includes buffer.
 #
 # Pre-requisites (run from login node before submitting):
 #   invoke assets.pull-llm --size 300m

--- a/scripts/hpc/llm_300m/14_train_e1.sh
+++ b/scripts/hpc/llm_300m/14_train_e1.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#BSUB -J danish_asr_llm_300m_e1
+#BSUB -q gpua100
+#BSUB -n 4
+#BSUB -R "rusage[mem=16GB]"
+#BSUB -R "span[hosts=1]"
+#BSUB -gpu "num=1:mode=exclusive_process"
+#BSUB -W 24:00
+#BSUB -B
+#BSUB -N
+#BSUB -u s204696@dtu.dk
+#BSUB -o /work3/s204696/logs/lsf/llm_300m_e1_%J.out
+#BSUB -e /work3/s204696/logs/lsf/llm_300m_e1_%J.err
+#
+# E1 full finetune: omniASR_LLM_300M_v2 on CoRal-v3 Danish, 20k steps.
+# A100-40GB is sufficient for LLM_300M_v2 at max_audio_len=240k (15s).
+#
+# Timing estimate: LLM decoder is ~30x slower per step than CTC (~96x RTF
+# vs ~1x). Expect 18-22h for 20k steps. 24h walltime includes buffer.
+#
+# Pre-requisites (run from login node before submitting):
+#   invoke assets.pull-llm --size 300m
+#   bsub < scripts/hpc/llm_300m/05_smoke_test.sh  # verify first
+#
+# Usage:
+#   bsub < scripts/hpc/llm_300m/14_train_e1.sh
+#
+# Resume support: resubmitting this script will auto-resume from the latest
+# checkpoint if training is interrupted.
+
+set -euo pipefail
+
+source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
+setup_omniasr
+
+RUN_DIR="${RESUME_DIR:-/work3/$USER/outputs/omniasr_llm_300m_e1}"
+mkdir -p "$RUN_DIR"
+
+python scripts/hpc/run_training.py \
+    --config configs/fairseq2/llm_300m/llm-finetune-hpc-e1.yaml \
+    --output-dir "$RUN_DIR" \
+    --wandb-tags "train,full,hpc,a100,llm_300m_v2,e1,20k,lr5e-5,shuffle1000" \
+    --wandb-resume allow

--- a/scripts/hpc/pull_llm_assets.py
+++ b/scripts/hpc/pull_llm_assets.py
@@ -1,0 +1,45 @@
+"""Pre-download omniASR LLM V2 checkpoint + tokenizer to FAIRSEQ2_CACHE_DIR.
+
+Run on the DTU HPC login node (or locally) before submitting a training job so
+the compute node does not spend GPU-allocated time downloading multi-GiB
+checkpoints. Fairseq2's asset cache is content-addressed, so re-running is safe.
+
+Usage:
+    uv run python scripts/hpc/pull_llm_assets.py --size 300m
+    uv run python scripts/hpc/pull_llm_assets.py --size 1b
+
+The FAIRSEQ2_CACHE_DIR env var (set by scripts/hpc/env.sh) controls where
+assets land. On DTU HPC this resolves to /work3/$USER/fairseq2_cache/.
+"""
+
+import argparse
+import os
+
+CARDS: dict[str, str] = {
+    "300m": "omniASR_LLM_300M_v2",
+    "1b": "omniASR_LLM_1B_v2",
+}
+
+SIZES: dict[str, str] = {
+    "300m": "6.1 GiB",
+    "1b": "8.5 GiB",
+}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--size", choices=sorted(CARDS), required=True, help="Model size to pre-download.")
+    args = ap.parse_args()
+
+    card = CARDS[args.size]
+    cache = os.environ.get("FAIRSEQ2_CACHE_DIR", "~/.cache/fairseq2/assets")
+    print(f"Downloading {card} (~{SIZES[args.size]}) → {cache}")
+
+    from omnilingual_asr.models.inference.pipeline import ASRInferencePipeline
+
+    ASRInferencePipeline(model_card=card)
+    print(f"Done: {card} cached at {cache}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.py
+++ b/tasks.py
@@ -34,6 +34,7 @@ quality = load_module_from_file("quality", tasks_dir / "quality.py")
 dvc_tasks = load_module_from_file("dvc_tasks", tasks_dir / "dvc_tasks.py")
 docs = load_module_from_file("docs", tasks_dir / "docs.py")
 utils = load_module_from_file("utils", tasks_dir / "utils.py")
+assets = load_module_from_file("assets", tasks_dir / "assets.py")
 
 namespace = Collection()
 
@@ -44,3 +45,4 @@ namespace.add_collection(Collection.from_module(quality), name="quality")
 namespace.add_collection(Collection.from_module(dvc_tasks), name="dvc")
 namespace.add_collection(Collection.from_module(docs), name="docs")
 namespace.add_collection(Collection.from_module(utils), name="utils")
+namespace.add_collection(Collection.from_module(assets), name="assets")

--- a/tasks/assets.py
+++ b/tasks/assets.py
@@ -1,0 +1,23 @@
+"""Asset management tasks (model checkpoint pre-download)."""
+
+from pathlib import Path
+
+from invoke import Context, task
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PULL_SCRIPT = PROJECT_ROOT / "scripts" / "hpc" / "pull_llm_assets.py"
+
+
+@task(name="pull-llm")
+def pull_llm(ctx: Context, size: str = "300m") -> None:
+    """Pre-download omniASR_LLM_{300m,1b}_v2 checkpoint to FAIRSEQ2_CACHE_DIR.
+
+    Run on the DTU HPC login node (or locally) before submitting a training
+    job. Respects the FAIRSEQ2_CACHE_DIR env var set by scripts/hpc/env.sh
+    (/work3/$USER/fairseq2_cache on HPC).
+
+    Usage:
+        invoke assets.pull-llm --size 300m
+        invoke assets.pull-llm --size 1b
+    """
+    ctx.run(f"uv run python {PULL_SCRIPT} --size {size}", echo=True, pty=True)

--- a/tasks/assets.py
+++ b/tasks/assets.py
@@ -1,16 +1,29 @@
 """Asset management tasks (model checkpoint pre-download)."""
 
+import importlib.util
+import os
+import shlex
 from pathlib import Path
 
 from invoke import Context, task
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ENV_SCRIPT = PROJECT_ROOT / "scripts" / "hpc" / "env.sh"
 PULL_SCRIPT = PROJECT_ROOT / "scripts" / "hpc" / "pull_llm_assets.py"
+VALID_SIZES = {"300m", "1b"}
+WINDOWS = os.name == "nt"
+
+
+def _has_module(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except ModuleNotFoundError:
+        return False
 
 
 @task(name="pull-llm")
 def pull_llm(ctx: Context, size: str = "300m") -> None:
-    """Pre-download omniASR_LLM_{300m,1b}_v2 checkpoint to FAIRSEQ2_CACHE_DIR.
+    """Pre-download omniASR_LLM_300M_v2 or omniASR_LLM_1B_v2 to FAIRSEQ2_CACHE_DIR.
 
     Run on the DTU HPC login node (or locally) before submitting a training
     job. Respects the FAIRSEQ2_CACHE_DIR env var set by scripts/hpc/env.sh
@@ -20,4 +33,20 @@ def pull_llm(ctx: Context, size: str = "300m") -> None:
         invoke assets.pull-llm --size 300m
         invoke assets.pull-llm --size 1b
     """
-    ctx.run(f"uv run python {PULL_SCRIPT} --size {size}", echo=True, pty=True)
+    if size not in VALID_SIZES:
+        raise ValueError(f"Invalid size {size!r}. Must be one of: {sorted(VALID_SIZES)}")
+
+    cmd = f"python {shlex.quote(str(PULL_SCRIPT))} --size {shlex.quote(size)}"
+
+    if _has_module("omnilingual_asr"):
+        ctx.run(cmd, echo=True, pty=not WINDOWS)
+        return
+
+    if WINDOWS:
+        raise RuntimeError(
+            "omnilingual_asr is not installed in the active environment. "
+            "Install the omni dependencies first or run this task from the HPC login node."
+        )
+
+    hpc_cmd = shlex.quote(f"source {ENV_SCRIPT} && setup_omniasr && {cmd}")
+    ctx.run(f"bash -lc {hpc_cmd}", echo=True, pty=not WINDOWS)

--- a/tasks/train.py
+++ b/tasks/train.py
@@ -23,6 +23,12 @@ def _resolve_omniasr_config(hardware: str) -> Path:
         return PROJECT_ROOT / "configs" / "fairseq2" / "300m" / "ctc-finetune-local.yaml"
     if hardware == "hpc":
         return PROJECT_ROOT / "configs" / "fairseq2" / "legacy" / "ctc-finetune-hpc.yaml"
+    if hardware.startswith("llm-300m"):
+        suffix = hardware.removeprefix("llm-300m-")
+        return PROJECT_ROOT / "configs" / "fairseq2" / "llm_300m" / f"llm-finetune-{suffix}.yaml"
+    if hardware.startswith("llm-1b"):
+        suffix = hardware.removeprefix("llm-1b-")
+        return PROJECT_ROOT / "configs" / "fairseq2" / "llm_1b" / f"llm-finetune-{suffix}.yaml"
     return PROJECT_ROOT / "configs" / "fairseq2" / "300m" / f"ctc-finetune-{hardware}.yaml"
 
 

--- a/tasks/train.py
+++ b/tasks/train.py
@@ -1,7 +1,9 @@
 """Training and hyperparameter tuning tasks."""
 
+import importlib.util
 import os
 import re
+import shlex
 from datetime import datetime
 from pathlib import Path
 
@@ -16,6 +18,34 @@ HPC_LOGIN = f"{HPC_USER}@login.hpc.dtu.dk"
 WINDOWS = os.name == "nt"
 PROJECT_NAME = "danish_asr"
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+ENV_SCRIPT = PROJECT_ROOT / "scripts" / "hpc" / "env.sh"
+
+
+def _has_module(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def _run_with_omni_workflows(ctx: Context, cmd: str) -> None:
+    if _has_module("workflows.recipes.wav2vec2.asr"):
+        ctx.run(cmd, echo=True, pty=not WINDOWS)
+        return
+
+    if WINDOWS:
+        logger.error(
+            "omnilingual-asr workflows are not installed in the active environment. "
+            "Install them first before using train.omniasr."
+        )
+        return
+
+    hpc_cmd = shlex.quote(f"source {ENV_SCRIPT} && setup_omniasr && {cmd}")
+    ctx.run(f"bash -lc {hpc_cmd}", echo=True, pty=not WINDOWS)
+
+
+def _available_llm_hardware(prefix: str, config_dir: Path) -> list[str]:
+    return sorted(f"{prefix}-{path.stem.removeprefix('llm-finetune-')}" for path in config_dir.glob("llm-finetune-*.yaml"))
 
 
 def _resolve_omniasr_config(hardware: str) -> Path:
@@ -23,12 +53,28 @@ def _resolve_omniasr_config(hardware: str) -> Path:
         return PROJECT_ROOT / "configs" / "fairseq2" / "300m" / "ctc-finetune-local.yaml"
     if hardware == "hpc":
         return PROJECT_ROOT / "configs" / "fairseq2" / "legacy" / "ctc-finetune-hpc.yaml"
-    if hardware.startswith("llm-300m"):
+    if hardware == "llm-300m":
+        available = ", ".join(_available_llm_hardware("llm-300m", PROJECT_ROOT / "configs" / "fairseq2" / "llm_300m"))
+        raise ValueError(f"Invalid hardware {hardware!r}. Available 300M LLM targets: {available}")
+    if hardware == "llm-1b":
+        available = ", ".join(_available_llm_hardware("llm-1b", PROJECT_ROOT / "configs" / "fairseq2" / "llm_1b"))
+        raise ValueError(f"Invalid hardware {hardware!r}. Available 1B LLM targets: {available}")
+    if hardware.startswith("llm-300m-"):
+        config_dir = PROJECT_ROOT / "configs" / "fairseq2" / "llm_300m"
         suffix = hardware.removeprefix("llm-300m-")
-        return PROJECT_ROOT / "configs" / "fairseq2" / "llm_300m" / f"llm-finetune-{suffix}.yaml"
-    if hardware.startswith("llm-1b"):
+        config = config_dir / f"llm-finetune-{suffix}.yaml"
+        if not config.exists():
+            available = ", ".join(_available_llm_hardware("llm-300m", config_dir))
+            raise ValueError(f"Unknown hardware {hardware!r}. Available 300M LLM targets: {available}")
+        return config
+    if hardware.startswith("llm-1b-"):
+        config_dir = PROJECT_ROOT / "configs" / "fairseq2" / "llm_1b"
         suffix = hardware.removeprefix("llm-1b-")
-        return PROJECT_ROOT / "configs" / "fairseq2" / "llm_1b" / f"llm-finetune-{suffix}.yaml"
+        config = config_dir / f"llm-finetune-{suffix}.yaml"
+        if not config.exists():
+            available = ", ".join(_available_llm_hardware("llm-1b", config_dir))
+            raise ValueError(f"Unknown hardware {hardware!r}. Available 1B LLM targets: {available}")
+        return config
     return PROJECT_ROOT / "configs" / "fairseq2" / "300m" / f"ctc-finetune-{hardware}.yaml"
 
 
@@ -75,11 +121,16 @@ def sweep_best(ctx: Context, sweep_id: str, metric: str = "val_acc", goal: str =
 
 @task
 def omniasr(ctx: Context, hardware: str = "local", output_dir: str = "", args: str = "") -> None:
-    """Train omniASR_CTC_300M_v2 via fairseq2 recipe."""
-    config = _resolve_omniasr_config(hardware)
+    """Train omniASR via the fairseq2 recipe."""
+    try:
+        config = _resolve_omniasr_config(hardware)
+    except ValueError as exc:
+        logger.error(str(exc))
+        return
+
     if not config.exists():
         logger.error(f"Config not found: {config}")
-        logger.error("Available: local, hpc, or explicit 300m config suffixes like hpc-20k")
+        logger.error("Available: local, hpc, ctc config suffixes like hpc-20k, or LLM targets like llm-300m-smoke")
         return
 
     if not output_dir:
@@ -87,11 +138,11 @@ def omniasr(ctx: Context, hardware: str = "local", output_dir: str = "", args: s
         output_dir = str(PROJECT_ROOT / "outputs" / f"omniasr_{hardware}_{timestamp}")
 
     Path(output_dir).mkdir(parents=True, exist_ok=True)
-    cmd = f"uv run python -m workflows.recipes.wav2vec2.asr {output_dir} --config-file {config}"
+    cmd = f"python -m workflows.recipes.wav2vec2.asr {shlex.quote(output_dir)} --config-file {shlex.quote(str(config))}"
     if args:
         cmd += f" {args}"
     logger.info(f"Starting omniASR training: hardware={hardware}, output={output_dir}")
-    ctx.run(cmd, echo=True, pty=not WINDOWS)
+    _run_with_omni_workflows(ctx, cmd)
 
 
 @task(name="hpc-smoke")
@@ -155,6 +206,9 @@ def omniasr_eval(ctx: Context, checkpoint_dir: str, config: str = "") -> None:
         logger.error(f"Checkpoint dir not found: {checkpoint_dir}")
         return
 
-    cmd = f"uv run python -m workflows.recipes.wav2vec2.asr.eval {checkpoint_dir} --config-file {config_path}"
+    cmd = (
+        f"python -m workflows.recipes.wav2vec2.asr.eval {shlex.quote(checkpoint_dir)} "
+        f"--config-file {shlex.quote(str(config_path))}"
+    )
     logger.info(f"Evaluating omniASR: checkpoint={checkpoint_dir}, config={config_path}")
-    ctx.run(cmd, echo=True, pty=not WINDOWS)
+    _run_with_omni_workflows(ctx, cmd)

--- a/tasks/train.py
+++ b/tasks/train.py
@@ -45,7 +45,9 @@ def _run_with_omni_workflows(ctx: Context, cmd: str) -> None:
 
 
 def _available_llm_hardware(prefix: str, config_dir: Path) -> list[str]:
-    return sorted(f"{prefix}-{path.stem.removeprefix('llm-finetune-')}" for path in config_dir.glob("llm-finetune-*.yaml"))
+    return sorted(
+        f"{prefix}-{path.stem.removeprefix('llm-finetune-')}" for path in config_dir.glob("llm-finetune-*.yaml")
+    )
 
 
 def _resolve_omniasr_config(hardware: str) -> Path:


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for finetuning omniASR LLM V2 models (300M and 1B variants) on Danish ASR data. It includes training configurations, HPC job submission scripts, asset pre-download utilities, and documentation updates.

## Key Changes

- **Training Configurations**: Added 4 new YAML configs under `configs/fairseq2/`:
  - `llm_300m/llm-finetune-hpc-e1.yaml` — 20k-step full training for 300M model on A100-40GB
  - `llm_300m/llm-finetune-smoke.yaml` — 50-step validation run
  - `llm_1b/llm-finetune-hpc-e1-1b.yaml` — 20k-step full training for 1B model on A100-80GB
  - `llm_1b/llm-finetune-smoke.yaml` — 50-step validation run

- **HPC Job Scripts**: Added 4 LSF batch submission scripts under `scripts/hpc/`:
  - `llm_300m/05_smoke_test.sh` and `14_train_e1.sh`
  - `llm_1b/05_smoke_test.sh` and `14_train_e1_1b.sh`
  - Scripts include resource requests (A100-40GB for 300M, A100-80GB for 1B), timing estimates, and resume support

- **Asset Management**: 
  - Added `scripts/hpc/pull_llm_assets.py` — utility to pre-download 6–8.5 GiB checkpoints to `FAIRSEQ2_CACHE_DIR` before training
  - Added `tasks/assets.py` — Invoke task `invoke assets.pull-llm --size {300m,1b}` for convenient pre-pulling

- **Documentation**:
  - Updated `docs/finetuning-recipe.md` with LLM V2 section covering key differences (O(seq²) decoder activations, 240k max audio length, inference speed, checkpoint sizes)
  - Updated `docs/omnilingual-asr-overview.md` with LLM V2 finetuning strategies and limitations

- **Task Integration**: Extended `tasks/train.py` to support `llm-300m-*` and `llm-1b-*` hardware targets for config resolution

## Notable Implementation Details

- **Memory Constraints**: LLM decoder activations scale quadratically with sequence length; `max_audio_len` capped at 240,000 samples (15s) vs. CTC's 960,000 (60s)
- **Gradient Accumulation**: 300M uses 8 batches, 1B uses 16 batches to maintain effective batch size relative to 300M CTC track
- **Pre-download Strategy**: Checkpoints are 6–8.5 GiB; pre-pulling on login node avoids burning GPU-allocated compute time on downloads
- **Resume Support**: HPC scripts use `RESUME_DIR` env var and `--wandb-resume allow` for automatic checkpoint resumption on resubmission
- **Smoke Testing**: 50-step validation runs verify full pipeline (model load, data, forward/backward, checkpoint) before committing to 20k-step training

https://claude.ai/code/session_01JGUxqyvA78jBu3Pvkrd59A