### PR TITLE
[codex] Fix 300M LLM HPC log paths

### DIFF
--- a/scripts/hpc/llm_300m/14_train_e1.sh
+++ b/scripts/hpc/llm_300m/14_train_e1.sh
@@ -8,8 +8,8 @@
 #BSUB -W 24:00
 #BSUB -B
 #BSUB -N
-#BSUB -o /work3/%U/logs/lsf/llm_300m_e1_%J.out
-#BSUB -e /work3/%U/logs/lsf/llm_300m_e1_%J.err
+#BSUB -o /work3/s204696/logs/lsf/llm_300m_e1_%J.out
+#BSUB -e /work3/s204696/logs/lsf/llm_300m_e1_%J.err
 #
 # E1 full finetune: omniASR_LLM_300M_v2 on CoRal-v3 Danish, 20k steps.
 # A100-40GB is sufficient for LLM_300M_v2 at max_audio_len=240k (15s).


### PR DESCRIPTION
## Summary

- Update the 300M LLM E1 HPC script to write LSF stdout/stderr to the concrete `/work3/s204696/logs/lsf` path.

## Why

The submitted HPC environment expects the explicit scratch user path for these LSF log files. This keeps the 300M LLM launch script aligned with the working cluster path convention.

## Validation

- `bash -n scripts/hpc/llm_300m/14_train_e1.sh`
- Pre-commit hooks from `git commit` passed, including whitespace, EOF, merge-conflict, private-key, large-file, secret, and codespell checks.