### PR TITLE
Fixed per-subset base eval configs and shell scripts: the test_<corpu…

### DIFF
--- a/configs/fairseq2/1b/ctc-eval-base-conversation.yaml
+++ b/configs/fairseq2/1b/ctc-eval-base-conversation.yaml
@@ -1,8 +1,10 @@
 # Zero-shot evaluation of pretrained omniASR_CTC_1B_v2 — conversation subset only.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
-# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
-# No subset TSV required.
+# Subset filtering: valid_split "test" scoped to the conversation corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe (falls back to full combined test set). The shell
+# script generates the subset TSV from language_distribution_0.tsv before running.
 #
 # Used by: scripts/hpc/1b/20_eval_base_1b.sh
 
@@ -11,11 +13,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_conversation"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_conversation.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/1b/ctc-eval-base-read-aloud.yaml
+++ b/configs/fairseq2/1b/ctc-eval-base-read-aloud.yaml
@@ -1,8 +1,10 @@
 # Zero-shot evaluation of pretrained omniASR_CTC_1B_v2 — read_aloud subset only.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
-# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
-# No subset TSV required.
+# Subset filtering: valid_split "test" scoped to the read_aloud corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe (falls back to full combined test set). The shell
+# script generates the subset TSV from language_distribution_0.tsv before running.
 #
 # Used by: scripts/hpc/1b/20_eval_base_1b.sh
 
@@ -11,11 +13,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_read_aloud"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_read_aloud.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/300m/ctc-eval-base-conversation.yaml
+++ b/configs/fairseq2/300m/ctc-eval-base-conversation.yaml
@@ -1,8 +1,10 @@
 # Zero-shot evaluation of pretrained omniASR_CTC_300M_v2 — conversation subset only.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
-# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
-# No subset TSV required — the combined TSV is used for discovery only (ignored during eval).
+# Subset filtering: valid_split "test" scoped to the conversation corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe (falls back to full combined test set). The shell
+# script generates the subset TSV from language_distribution_0.tsv before running.
 #
 # Used by: scripts/hpc/300m/20_eval_base.sh
 
@@ -13,11 +15,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_conversation"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_conversation.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/300m/ctc-eval-base-read-aloud.yaml
+++ b/configs/fairseq2/300m/ctc-eval-base-read-aloud.yaml
@@ -1,8 +1,10 @@
 # Zero-shot evaluation of pretrained omniASR_CTC_300M_v2 — read_aloud subset only.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
-# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
-# No subset TSV required — the combined TSV is used for discovery only (ignored during eval).
+# Subset filtering: valid_split "test" scoped to the read_aloud corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe (falls back to full combined test set). The shell
+# script generates the subset TSV from language_distribution_0.tsv before running.
 #
 # Used by: scripts/hpc/300m/20_eval_base.sh
 
@@ -13,11 +15,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_read_aloud"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_read_aloud.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/3b/ctc-eval-base-3b-conversation.yaml
+++ b/configs/fairseq2/3b/ctc-eval-base-3b-conversation.yaml
@@ -1,8 +1,10 @@
 # Zero-shot evaluation of pretrained omniASR_CTC_3B_v2 — conversation subset only.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
-# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
-# No subset TSV required.
+# Subset filtering: valid_split "test" scoped to the conversation corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe (falls back to full combined test set). The shell
+# script generates the subset TSV from language_distribution_0.tsv before running.
 #
 # Used by: scripts/hpc/3b/19_eval_base_3b.sh
 
@@ -11,11 +13,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_conversation"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_conversation.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml
+++ b/configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml
@@ -1,8 +1,10 @@
 # Zero-shot evaluation of pretrained omniASR_CTC_3B_v2 — read_aloud subset only.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
-# Subset filtering uses fairseq2's built-in "<split>_<corpus>" valid_split format.
-# No subset TSV required.
+# Subset filtering: valid_split "test" scoped to the read_aloud corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe (falls back to full combined test set). The shell
+# script generates the subset TSV from language_distribution_0.tsv before running.
 #
 # Used by: scripts/hpc/3b/19_eval_base_3b.sh
 
@@ -11,11 +13,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_read_aloud"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_read_aloud.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/llm_1b/llm-eval-base-1b-conversation.yaml
+++ b/configs/fairseq2/llm_1b/llm-eval-base-1b-conversation.yaml
@@ -2,6 +2,11 @@
 # conversation test subset.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
+# Subset filtering: valid_split "test" scoped to the conversation corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is not supported for
+# LLM model families and causes an immediate exit. The shell script generates the
+# subset TSV from language_distribution_0.tsv before running this config.
+#
 # Used by: scripts/hpc/llm_1b/19_eval_base_1b.sh
 
 model:
@@ -11,11 +16,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_conversation"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_conversation.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/llm_1b/llm-eval-base-1b-read-aloud.yaml
+++ b/configs/fairseq2/llm_1b/llm-eval-base-1b-read-aloud.yaml
@@ -2,6 +2,11 @@
 # read_aloud test subset.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
+# Subset filtering: valid_split "test" scoped to the read_aloud corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is not supported for
+# LLM model families and causes an immediate exit. The shell script generates the
+# subset TSV from language_distribution_0.tsv before running this config.
+#
 # Used by: scripts/hpc/llm_1b/19_eval_base_1b.sh
 
 model:
@@ -11,11 +16,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_read_aloud"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_read_aloud.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/llm_300m/llm-eval-base-conversation.yaml
+++ b/configs/fairseq2/llm_300m/llm-eval-base-conversation.yaml
@@ -2,6 +2,11 @@
 # conversation test subset.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
+# Subset filtering: valid_split "test" scoped to the conversation corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is not supported for
+# LLM model families and causes an immediate exit. The shell script generates the
+# subset TSV from language_distribution_0.tsv before running this config.
+#
 # Used by: scripts/hpc/llm_300m/19_eval_base.sh
 
 model:
@@ -11,11 +16,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_conversation"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_conversation.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/configs/fairseq2/llm_300m/llm-eval-base-read-aloud.yaml
+++ b/configs/fairseq2/llm_300m/llm-eval-base-read-aloud.yaml
@@ -2,6 +2,11 @@
 # read_aloud test subset.
 # No model.path — fairseq2 loads the pretrained checkpoint from the asset registry.
 #
+# Subset filtering: valid_split "test" scoped to the read_aloud corpus via a
+# corpus-filtered TSV. The "test_<corpus>" split-name suffix is not supported for
+# LLM model families and causes an immediate exit. The shell script generates the
+# subset TSV from language_distribution_0.tsv before running this config.
+#
 # Used by: scripts/hpc/llm_300m/19_eval_base.sh
 
 model:
@@ -11,11 +16,11 @@ model:
 
 dataset:
   name: "coral_v3_danish"
-  valid_split: "test_coral_v3_read_aloud"
+  valid_split: "test"
   storage_mode: "MIXTURE_PARQUET"
   task_mode: "ASR"
   mixture_parquet_storage_config:
-    dataset_summary_path: "data/parquet/version=0/language_distribution_0.tsv"
+    dataset_summary_path: "data/parquet/version=0/language_distribution_read_aloud.tsv"
     beta_corpus: 0.5
     beta_language: 0.5
     fragment_loading:

--- a/scripts/hpc/1b/20_eval_base_1b.sh
+++ b/scripts/hpc/1b/20_eval_base_1b.sh
@@ -41,6 +41,16 @@ echo "Started:        $(date)"
 echo "Node:           $(hostname)"
 nvidia-smi
 
+# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
+# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe and falls back to the full combined test set.
+MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_conversation.tsv"
+echo "Generated per-corpus subset TSVs from $MAIN_TSV"
+
 had_failures=0
 
 split_tag() {

--- a/scripts/hpc/300m/20_eval_base.sh
+++ b/scripts/hpc/300m/20_eval_base.sh
@@ -41,6 +41,16 @@ echo "Started:        $(date)"
 echo "Node:           $(hostname)"
 nvidia-smi
 
+# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
+# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe and falls back to the full combined test set.
+MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_conversation.tsv"
+echo "Generated per-corpus subset TSVs from $MAIN_TSV"
+
 had_failures=0
 
 # Derive W&B split tag from the config filename suffix.

--- a/scripts/hpc/3b/19_eval_base_3b.sh
+++ b/scripts/hpc/3b/19_eval_base_3b.sh
@@ -42,6 +42,16 @@ echo "Started:        $(date)"
 echo "Node:           $(hostname)"
 nvidia-smi
 
+# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
+# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
+# by the wav2vec2_asr recipe and falls back to the full combined test set.
+MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_conversation.tsv"
+echo "Generated per-corpus subset TSVs from $MAIN_TSV"
+
 had_failures=0
 
 split_tag() {

--- a/scripts/hpc/llm_1b/19_eval_base_1b.sh
+++ b/scripts/hpc/llm_1b/19_eval_base_1b.sh
@@ -42,6 +42,16 @@ echo "Started:        $(date)"
 echo "Node:           $(hostname)"
 nvidia-smi
 
+# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
+# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix causes an immediate
+# exit for wav2vec2_llama model families and is not used here.
+MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_conversation.tsv"
+echo "Generated per-corpus subset TSVs from $MAIN_TSV"
+
 had_failures=0
 
 split_tag() {

--- a/scripts/hpc/llm_300m/19_eval_base.sh
+++ b/scripts/hpc/llm_300m/19_eval_base.sh
@@ -41,6 +41,16 @@ echo "Started:        $(date)"
 echo "Node:           $(hostname)"
 nvidia-smi
 
+# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
+# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix causes an immediate
+# exit for wav2vec2_llama model families and is not used here.
+MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
+{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
+    > "data/parquet/version=0/language_distribution_conversation.tsv"
+echo "Generated per-corpus subset TSVs from $MAIN_TSV"
+
 had_failures=0
 
 split_tag() {


### PR DESCRIPTION
…s> split-name suffix was silently ignored by the wav2vec2_asr recipe (falling back to the full combined test set) and caused an immediate exit for wav2vec2_llama model families — so all six per-split base eval configs were evaluating on the full combined test set regardless. Switched valid_split to test across all configs (300m, 1b, 3b, llm_300m, llm_1b — both read_aloud and conversation variants) and changed dataset_summary_path to corpus-filtered TSVs (language_distribution_read_aloud.tsv / language_distribution_conversation.tsv). Each shell script now generates these filtered TSVs from language_distribution_0.tsv via awk before running eval, so subset scoping is handled entirely at the TSV level rather than relying on the split-name suffix