### PR TITLE
Fix zero-shot base eval scripts to produce correct per-subset WER

### DIFF
--- a/configs/eval/ctc_kenlm_finetuned_hpc.yaml
+++ b/configs/eval/ctc_kenlm_finetuned_hpc.yaml
@@ -34,6 +34,18 @@ my_method:
       split: test_coral_v3_conversation
 
 models:
+  - label: 300m_base
+    arch: 300m_v2
+    checkpoint_path: /work3/${USER}/fairseq2_cache/f33741966d852362f4d416d5/omniASR-CTC-300M-v2.pt
+    batch_size: 4
+  - label: 1b_base
+    arch: 1b_v2
+    checkpoint_path: /work3/${USER}/fairseq2_cache/fca49af82b51089226da7de9/omniASR-CTC-1B-v2.pt
+    batch_size: 2
+  - label: 3b_base
+    arch: 3b_v2
+    checkpoint_path: /work3/${USER}/fairseq2_cache/0a31b71a234e317bd6f84e33/omniASR-CTC-3B-v2.pt
+    batch_size: 1
   - label: 300m_e6_50k
     arch: 300m_v2
     checkpoint_path: /work3/${USER}/models/ctc/300m_e6_50k/omniASR_CTC_300M_v2_e6_step50k.pt

--- a/configs/eval/ctc_kenlm_finetuned_hpc.yaml
+++ b/configs/eval/ctc_kenlm_finetuned_hpc.yaml
@@ -34,18 +34,6 @@ my_method:
       split: test_coral_v3_conversation
 
 models:
-  - label: 300m_base
-    arch: 300m_v2
-    checkpoint_path: /work3/${USER}/fairseq2_cache/f33741966d852362f4d416d5/omniASR-CTC-300M-v2.pt
-    batch_size: 4
-  - label: 1b_base
-    arch: 1b_v2
-    checkpoint_path: /work3/${USER}/fairseq2_cache/fca49af82b51089226da7de9/omniASR-CTC-1B-v2.pt
-    batch_size: 2
-  - label: 3b_base
-    arch: 3b_v2
-    checkpoint_path: /work3/${USER}/fairseq2_cache/0a31b71a234e317bd6f84e33/omniASR-CTC-3B-v2.pt
-    batch_size: 1
   - label: 300m_e6_50k
     arch: 300m_v2
     checkpoint_path: /work3/${USER}/models/ctc/300m_e6_50k/omniASR_CTC_300M_v2_e6_step50k.pt

--- a/scripts/hpc/1b/20_eval_base_1b.sh
+++ b/scripts/hpc/1b/20_eval_base_1b.sh
@@ -12,77 +12,72 @@
 #BSUB -o /work3/s204696/logs/lsf/eval_base_1b_%J.out
 #BSUB -e /work3/s204696/logs/lsf/eval_base_1b_%J.err
 #
-# Zero-shot evaluation of pretrained omniASR_CTC_1B_v2 on 3 test splits.
-# No checkpoint needed — model loaded from fairseq2 asset registry.
-# Walltime 2:00 covers 3 sequential splits (~30-40 min each).
+# Zero-shot greedy evaluation of pretrained omniASR_CTC_1B_v2 on 3 test splits.
+# Uses the parquet harness (decode_ctc_with_lm.py) so per-corpus subset WER is
+# correct — the fairseq2 recipe evaluates on the full combined set regardless of
+# the split name suffix or dataset_summary_path TSV.
 #
 # Usage:
 #   bsub < scripts/hpc/1b/20_eval_base_1b.sh
-#
-# Single-split override:
-#   EVAL_CONFIG=configs/fairseq2/1b/ctc-eval-base-read-aloud.yaml \
-#       bsub < scripts/hpc/1b/20_eval_base_1b.sh
 
 set -euo pipefail
 
 source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
 setup_omniasr
 
-EVAL_OUT_DIR="${EVAL_OUT_DIR:-/work3/$USER/outputs/omniasr_base_1b_eval}"
-if ! mkdir -p "$EVAL_OUT_DIR" 2>/dev/null; then
-    echo "ERROR: Cannot create eval workspace: $EVAL_OUT_DIR" >&2
-    echo "ERROR: Check /work3 quota with getquota_work3.sh" >&2
-    exit 1
-fi
+CHECKPOINT="/work3/$USER/fairseq2_cache/fca49af82b51089226da7de9/omniASR-CTC-1B-v2.pt"
+DATASET_ROOT="/work3/$USER/data/parquet/version=0"
+OUTPUT_ROOT="${OUTPUT_ROOT:-/work3/$USER/outputs/ctc_zero_shot}"
+BATCH_SIZE="${BATCH_SIZE:-2}"
+DTYPE="${DTYPE:-bfloat16}"
+OVERWRITE="${OVERWRITE:-false}"
 
-echo "=== Phase 8B: 1B Base (Zero-Shot) Evaluation ==="
-echo "Eval workspace: $EVAL_OUT_DIR"
-echo "Started:        $(date)"
-echo "Node:           $(hostname)"
+echo "=== 1B Base (Zero-Shot) Greedy Evaluation ==="
+echo "Checkpoint:  $CHECKPOINT"
+echo "Output root: $OUTPUT_ROOT"
+echo "Started:     $(date)"
+echo "Node:        $(hostname)"
 nvidia-smi
-
-# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
-# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
-# by the wav2vec2_asr recipe and falls back to the full combined test set.
-MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
-{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
-    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
-{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
-    > "data/parquet/version=0/language_distribution_conversation.tsv"
-echo "Generated per-corpus subset TSVs from $MAIN_TSV"
 
 had_failures=0
 
-split_tag() {
-    case "$1" in
-        *read-aloud*)   echo "read_aloud" ;;
-        *conversation*) echo "conversation" ;;
-        *)              echo "combined" ;;
-    esac
-}
+run_split() {
+    local split_label="$1"
+    local dataset_split="$2"
+    local run_dir="$OUTPUT_ROOT/1b_base/$split_label/greedy"
 
-CONFIGS=(
-    "configs/fairseq2/1b/ctc-eval-base.yaml"
-    "configs/fairseq2/1b/ctc-eval-base-read-aloud.yaml"
-    "configs/fairseq2/1b/ctc-eval-base-conversation.yaml"
-)
-
-for i in "${!CONFIGS[@]}"; do
-    CONFIG="${EVAL_CONFIG:-${CONFIGS[$i]}}"
-    TAGS="base,1b,zero-shot,test,$(split_tag "$CONFIG")"
-    echo ""
-    echo "--- Split $((i+1))/3: $CONFIG ---"
-
-    if ! python scripts/hpc/run_eval.py \
-        --checkpoint-dir "$EVAL_OUT_DIR" \
-        --config "$CONFIG" \
-        --wandb-tags "$TAGS"; then
-        echo "ERROR: Eval failed for $CONFIG" >&2
-        had_failures=1
+    if [[ -f "$run_dir/SUCCESS" && "$OVERWRITE" != "true" ]]; then
+        echo "Skipping completed split: $split_label"
+        return 0
     fi
 
-    if [ -n "${EVAL_CONFIG:-}" ]; then break; fi
-done
+    mkdir -p "$run_dir"
+    rm -f "$run_dir/SUCCESS" "$run_dir/FAILED"
+
+    echo ""
+    echo "--- Split: $split_label ($dataset_split) ---"
+    if python scripts/decode_ctc_with_lm.py \
+        --checkpoint-path "$CHECKPOINT" \
+        --model-arch 1b_v2 \
+        --dataset-root "$DATASET_ROOT" \
+        --dataset-split "$dataset_split" \
+        --decoder greedy \
+        --batch-size "$BATCH_SIZE" \
+        --dtype "$DTYPE" \
+        --output-dir "$run_dir" \
+        > "$run_dir/run.log" 2>&1; then
+        date > "$run_dir/SUCCESS"
+    else
+        echo "$?" > "$run_dir/FAILED"
+        echo "ERROR: Eval failed for $split_label" >&2
+        tail -40 "$run_dir/run.log" >&2 || true
+        had_failures=1
+    fi
+}
+
+run_split combined             test
+run_split read_aloud           test_coral_v3_read_aloud
+run_split conversation         test_coral_v3_conversation
 
 echo ""
 echo "Finished: $(date)"

--- a/scripts/hpc/1b/20_eval_base_1b.sh
+++ b/scripts/hpc/1b/20_eval_base_1b.sh
@@ -32,6 +32,12 @@ BATCH_SIZE="${BATCH_SIZE:-2}"
 DTYPE="${DTYPE:-bfloat16}"
 OVERWRITE="${OVERWRITE:-false}"
 
+if [[ ! -f "$CHECKPOINT" ]]; then
+    echo "ERROR: Checkpoint not found: $CHECKPOINT" >&2
+    echo "ERROR: Re-run a zero-shot eval to repopulate the fairseq2 cache, or set CHECKPOINT=<path>." >&2
+    exit 1
+fi
+
 echo "=== 1B Base (Zero-Shot) Greedy Evaluation ==="
 echo "Checkpoint:  $CHECKPOINT"
 echo "Output root: $OUTPUT_ROOT"

--- a/scripts/hpc/300m/20_eval_base.sh
+++ b/scripts/hpc/300m/20_eval_base.sh
@@ -32,6 +32,12 @@ BATCH_SIZE="${BATCH_SIZE:-4}"
 DTYPE="${DTYPE:-bfloat16}"
 OVERWRITE="${OVERWRITE:-false}"
 
+if [[ ! -f "$CHECKPOINT" ]]; then
+    echo "ERROR: Checkpoint not found: $CHECKPOINT" >&2
+    echo "ERROR: Re-run a zero-shot eval to repopulate the fairseq2 cache, or set CHECKPOINT=<path>." >&2
+    exit 1
+fi
+
 echo "=== 300M Base (Zero-Shot) Greedy Evaluation ==="
 echo "Checkpoint:  $CHECKPOINT"
 echo "Output root: $OUTPUT_ROOT"

--- a/scripts/hpc/300m/20_eval_base.sh
+++ b/scripts/hpc/300m/20_eval_base.sh
@@ -12,79 +12,72 @@
 #BSUB -o /work3/s204696/logs/lsf/eval_base_300m_%J.out
 #BSUB -e /work3/s204696/logs/lsf/eval_base_300m_%J.err
 #
-# Zero-shot evaluation of pretrained omniASR_CTC_300M_v2 on 3 test splits.
-# No checkpoint needed — model loaded from fairseq2 asset registry.
-# Walltime 2:00 covers 3 sequential splits (~30-40 min each).
+# Zero-shot greedy evaluation of pretrained omniASR_CTC_300M_v2 on 3 test splits.
+# Uses the parquet harness (decode_ctc_with_lm.py) so per-corpus subset WER is
+# correct — the fairseq2 recipe evaluates on the full combined set regardless of
+# the split name suffix or dataset_summary_path TSV.
 #
 # Usage:
 #   bsub < scripts/hpc/300m/20_eval_base.sh
-#
-# Single-split override:
-#   EVAL_CONFIG=configs/fairseq2/300m/ctc-eval-base-read-aloud.yaml \
-#       bsub < scripts/hpc/300m/20_eval_base.sh
 
 set -euo pipefail
 
 source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
 setup_omniasr
 
-EVAL_OUT_DIR="${EVAL_OUT_DIR:-/work3/$USER/outputs/omniasr_base_300m_eval}"
-if ! mkdir -p "$EVAL_OUT_DIR" 2>/dev/null; then
-    echo "ERROR: Cannot create eval workspace: $EVAL_OUT_DIR" >&2
-    echo "ERROR: Check /work3 quota with getquota_work3.sh" >&2
-    exit 1
-fi
+CHECKPOINT="/work3/$USER/fairseq2_cache/f33741966d852362f4d416d5/omniASR-CTC-300M-v2.pt"
+DATASET_ROOT="/work3/$USER/data/parquet/version=0"
+OUTPUT_ROOT="${OUTPUT_ROOT:-/work3/$USER/outputs/ctc_zero_shot}"
+BATCH_SIZE="${BATCH_SIZE:-4}"
+DTYPE="${DTYPE:-bfloat16}"
+OVERWRITE="${OVERWRITE:-false}"
 
-echo "=== Phase 8B: 300M Base (Zero-Shot) Evaluation ==="
-echo "Eval workspace: $EVAL_OUT_DIR"
-echo "Started:        $(date)"
-echo "Node:           $(hostname)"
+echo "=== 300M Base (Zero-Shot) Greedy Evaluation ==="
+echo "Checkpoint:  $CHECKPOINT"
+echo "Output root: $OUTPUT_ROOT"
+echo "Started:     $(date)"
+echo "Node:        $(hostname)"
 nvidia-smi
-
-# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
-# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
-# by the wav2vec2_asr recipe and falls back to the full combined test set.
-MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
-{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
-    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
-{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
-    > "data/parquet/version=0/language_distribution_conversation.tsv"
-echo "Generated per-corpus subset TSVs from $MAIN_TSV"
 
 had_failures=0
 
-# Derive W&B split tag from the config filename suffix.
-split_tag() {
-    case "$1" in
-        *read-aloud*)   echo "read_aloud" ;;
-        *conversation*) echo "conversation" ;;
-        *)              echo "combined" ;;
-    esac
-}
+run_split() {
+    local split_label="$1"
+    local dataset_split="$2"
+    local run_dir="$OUTPUT_ROOT/300m_base/$split_label/greedy"
 
-CONFIGS=(
-    "configs/fairseq2/300m/ctc-eval-base.yaml"
-    "configs/fairseq2/300m/ctc-eval-base-read-aloud.yaml"
-    "configs/fairseq2/300m/ctc-eval-base-conversation.yaml"
-)
-
-for i in "${!CONFIGS[@]}"; do
-    CONFIG="${EVAL_CONFIG:-${CONFIGS[$i]}}"
-    TAGS="base,300m,zero-shot,test,$(split_tag "$CONFIG")"
-    echo ""
-    echo "--- Split $((i+1))/3: $CONFIG ---"
-
-    if ! python scripts/hpc/run_eval.py \
-        --checkpoint-dir "$EVAL_OUT_DIR" \
-        --config "$CONFIG" \
-        --wandb-tags "$TAGS"; then
-        echo "ERROR: Eval failed for $CONFIG" >&2
-        had_failures=1
+    if [[ -f "$run_dir/SUCCESS" && "$OVERWRITE" != "true" ]]; then
+        echo "Skipping completed split: $split_label"
+        return 0
     fi
 
-    # If EVAL_CONFIG was set, run only that one config
-    if [ -n "${EVAL_CONFIG:-}" ]; then break; fi
-done
+    mkdir -p "$run_dir"
+    rm -f "$run_dir/SUCCESS" "$run_dir/FAILED"
+
+    echo ""
+    echo "--- Split: $split_label ($dataset_split) ---"
+    if python scripts/decode_ctc_with_lm.py \
+        --checkpoint-path "$CHECKPOINT" \
+        --model-arch 300m_v2 \
+        --dataset-root "$DATASET_ROOT" \
+        --dataset-split "$dataset_split" \
+        --decoder greedy \
+        --batch-size "$BATCH_SIZE" \
+        --dtype "$DTYPE" \
+        --output-dir "$run_dir" \
+        > "$run_dir/run.log" 2>&1; then
+        date > "$run_dir/SUCCESS"
+    else
+        echo "$?" > "$run_dir/FAILED"
+        echo "ERROR: Eval failed for $split_label" >&2
+        tail -40 "$run_dir/run.log" >&2 || true
+        had_failures=1
+    fi
+}
+
+run_split combined             test
+run_split read_aloud           test_coral_v3_read_aloud
+run_split conversation         test_coral_v3_conversation
 
 echo ""
 echo "Finished: $(date)"

--- a/scripts/hpc/3b/19_eval_base_3b.sh
+++ b/scripts/hpc/3b/19_eval_base_3b.sh
@@ -33,6 +33,12 @@ BATCH_SIZE="${BATCH_SIZE:-1}"
 DTYPE="${DTYPE:-bfloat16}"
 OVERWRITE="${OVERWRITE:-false}"
 
+if [[ ! -f "$CHECKPOINT" ]]; then
+    echo "ERROR: Checkpoint not found: $CHECKPOINT" >&2
+    echo "ERROR: Re-run a zero-shot eval to repopulate the fairseq2 cache, or set CHECKPOINT=<path>." >&2
+    exit 1
+fi
+
 echo "=== 3B Base (Zero-Shot) Greedy Evaluation ==="
 echo "Checkpoint:  $CHECKPOINT"
 echo "Output root: $OUTPUT_ROOT"

--- a/scripts/hpc/3b/19_eval_base_3b.sh
+++ b/scripts/hpc/3b/19_eval_base_3b.sh
@@ -13,77 +13,72 @@
 #BSUB -o /work3/s204696/logs/lsf/eval_base_3b_%J.out
 #BSUB -e /work3/s204696/logs/lsf/eval_base_3b_%J.err
 #
-# Zero-shot evaluation of pretrained omniASR_CTC_3B_v2 on 3 test splits.
-# No checkpoint needed — model loaded from fairseq2 asset registry.
-# Walltime 4:00 covers 3 sequential splits on A100-80GB.
+# Zero-shot greedy evaluation of pretrained omniASR_CTC_3B_v2 on 3 test splits.
+# Uses the parquet harness (decode_ctc_with_lm.py) so per-corpus subset WER is
+# correct — the fairseq2 recipe evaluates on the full combined set regardless of
+# the split name suffix or dataset_summary_path TSV.
 #
 # Usage:
 #   bsub < scripts/hpc/3b/19_eval_base_3b.sh
-#
-# Single-split override:
-#   EVAL_CONFIG=configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml \
-#       bsub < scripts/hpc/3b/19_eval_base_3b.sh
 
 set -euo pipefail
 
 source "${DANISH_ASR_PROJECT_DIR:-"$HOME/danish_asr"}/scripts/hpc/env.sh"
 setup_omniasr
 
-EVAL_OUT_DIR="${EVAL_OUT_DIR:-/work3/$USER/outputs/omniasr_base_3b_eval}"
-if ! mkdir -p "$EVAL_OUT_DIR" 2>/dev/null; then
-    echo "ERROR: Cannot create eval workspace: $EVAL_OUT_DIR" >&2
-    echo "ERROR: Check /work3 quota with getquota_work3.sh" >&2
-    exit 1
-fi
+CHECKPOINT="/work3/$USER/fairseq2_cache/0a31b71a234e317bd6f84e33/omniASR-CTC-3B-v2.pt"
+DATASET_ROOT="/work3/$USER/data/parquet/version=0"
+OUTPUT_ROOT="${OUTPUT_ROOT:-/work3/$USER/outputs/ctc_zero_shot}"
+BATCH_SIZE="${BATCH_SIZE:-1}"
+DTYPE="${DTYPE:-bfloat16}"
+OVERWRITE="${OVERWRITE:-false}"
 
-echo "=== Phase 10C: 3B Base (Zero-Shot) Evaluation ==="
-echo "Eval workspace: $EVAL_OUT_DIR"
-echo "Started:        $(date)"
-echo "Node:           $(hostname)"
+echo "=== 3B Base (Zero-Shot) Greedy Evaluation ==="
+echo "Checkpoint:  $CHECKPOINT"
+echo "Output root: $OUTPUT_ROOT"
+echo "Started:     $(date)"
+echo "Node:        $(hostname)"
 nvidia-smi
-
-# Generate per-corpus subset TSVs so the per-split configs can use valid_split: "test"
-# with a corpus-filtered TSV. The "test_<corpus>" split-name suffix is silently ignored
-# by the wav2vec2_asr recipe and falls back to the full combined test set.
-MAIN_TSV="data/parquet/version=0/language_distribution_0.tsv"
-{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_read_aloud"' "$MAIN_TSV"; } \
-    > "data/parquet/version=0/language_distribution_read_aloud.tsv"
-{ head -1 "$MAIN_TSV"; awk -F'\t' 'NR>1 && $1 == "coral_v3_conversation"' "$MAIN_TSV"; } \
-    > "data/parquet/version=0/language_distribution_conversation.tsv"
-echo "Generated per-corpus subset TSVs from $MAIN_TSV"
 
 had_failures=0
 
-split_tag() {
-    case "$1" in
-        *read-aloud*)   echo "read_aloud" ;;
-        *conversation*) echo "conversation" ;;
-        *)              echo "combined" ;;
-    esac
-}
+run_split() {
+    local split_label="$1"
+    local dataset_split="$2"
+    local run_dir="$OUTPUT_ROOT/3b_base/$split_label/greedy"
 
-CONFIGS=(
-    "configs/fairseq2/3b/ctc-eval-base-3b.yaml"
-    "configs/fairseq2/3b/ctc-eval-base-3b-read-aloud.yaml"
-    "configs/fairseq2/3b/ctc-eval-base-3b-conversation.yaml"
-)
-
-for i in "${!CONFIGS[@]}"; do
-    CONFIG="${EVAL_CONFIG:-${CONFIGS[$i]}}"
-    TAGS="base,3b,zero-shot,test,$(split_tag "$CONFIG")"
-    echo ""
-    echo "--- Split $((i+1))/3: $CONFIG ---"
-
-    if ! python scripts/hpc/run_eval.py \
-        --checkpoint-dir "$EVAL_OUT_DIR" \
-        --config "$CONFIG" \
-        --wandb-tags "$TAGS"; then
-        echo "ERROR: Eval failed for $CONFIG" >&2
-        had_failures=1
+    if [[ -f "$run_dir/SUCCESS" && "$OVERWRITE" != "true" ]]; then
+        echo "Skipping completed split: $split_label"
+        return 0
     fi
 
-    if [ -n "${EVAL_CONFIG:-}" ]; then break; fi
-done
+    mkdir -p "$run_dir"
+    rm -f "$run_dir/SUCCESS" "$run_dir/FAILED"
+
+    echo ""
+    echo "--- Split: $split_label ($dataset_split) ---"
+    if python scripts/decode_ctc_with_lm.py \
+        --checkpoint-path "$CHECKPOINT" \
+        --model-arch 3b_v2 \
+        --dataset-root "$DATASET_ROOT" \
+        --dataset-split "$dataset_split" \
+        --decoder greedy \
+        --batch-size "$BATCH_SIZE" \
+        --dtype "$DTYPE" \
+        --output-dir "$run_dir" \
+        > "$run_dir/run.log" 2>&1; then
+        date > "$run_dir/SUCCESS"
+    else
+        echo "$?" > "$run_dir/FAILED"
+        echo "ERROR: Eval failed for $split_label" >&2
+        tail -40 "$run_dir/run.log" >&2 || true
+        had_failures=1
+    fi
+}
+
+run_split combined             test
+run_split read_aloud           test_coral_v3_read_aloud
+run_split conversation         test_coral_v3_conversation
 
 echo ""
 echo "Finished: $(date)"


### PR DESCRIPTION
## Summary
- Rewrites `300m/20_eval_base.sh`, `1b/20_eval_base_1b.sh`, and `3b/19_eval_base_3b.sh` to use `decode_ctc_with_lm.py --decoder greedy` instead of `run_eval.py` backed by the fairseq2 recipe
- The fairseq2 `wav2vec2_asr` recipe ignores the split-name suffix (`test_coral_v3_read_aloud` etc.) at eval time and evaluates on the full combined test set regardless — all three per-subset configs were producing identical WER. The TSV workaround in the old scripts also had no effect: `dataset_summary_path` controls training corpus mixing, not eval filtering
- `decode_ctc_with_lm.py` constructs the parquet path directly from the split string via `parse_valid_split()`, so only files in `corpus=coral_v3_read_aloud/split=test/language=dan_Latn/` are read
- Adds explicit checkpoint existence check in all three scripts so a missing cache file fails fast with a clear error instead of a Python traceback mid-run
- Also reverts base model entries erroneously added to `ctc_kenlm_finetuned_hpc.yaml` in the first commit — those belong to the KenLM beam eval manifest and conflated two separate evaluation goals

## Test plan
- [ ] Merge and `git pull` on HPC
- [ ] `bsub < scripts/hpc/300m/20_eval_base.sh`
- [ ] `bsub < scripts/hpc/1b/20_eval_base_1b.sh`
- [ ] `bsub < scripts/hpc/3b/19_eval_base_3b.sh`
- [ ] Verify `read_aloud` and `conversation` WER differ from `combined` (confirming per-subset filtering works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)