### PR TITLE
[codex] Improve cached tokenizer path resolution

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,13 +1,18 @@
-# Graph Report - danish_asr  (2026-05-18)
+# Graph Report - danish_asr  (2026-06-05)
 
 ## Corpus Check
-- 206 files · ~286,405,285 words
+- 174 files · ~95,357 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 2644 nodes · 4766 edges · 231 communities detected
-- Extraction: 87% EXTRACTED · 13% INFERRED · 0% AMBIGUOUS · INFERRED: 611 edges (avg confidence: 0.74)
+- 3712 nodes · 5886 edges · 448 communities (228 shown, 220 thin omitted)
+- Extraction: 90% EXTRACTED · 10% INFERRED · 0% AMBIGUOUS · INFERRED: 575 edges (avg confidence: 0.74)
 - Token cost: 0 input · 0 output
+
+## Graph Freshness
+- Built from commit: `c8101409`
+- Run `git rev-parse HEAD` and compare to check if the graph is stale.
+- Run `graphify update .` after code changes (no API cost).
 
 ## Community Hubs (Navigation)
 - [[_COMMUNITY_Community 0|Community 0]]
@@ -241,10 +246,188 @@
 - [[_COMMUNITY_Community 264|Community 264]]
 - [[_COMMUNITY_Community 265|Community 265]]
 - [[_COMMUNITY_Community 266|Community 266]]
+- [[_COMMUNITY_Community 267|Community 267]]
+- [[_COMMUNITY_Community 268|Community 268]]
+- [[_COMMUNITY_Community 269|Community 269]]
+- [[_COMMUNITY_Community 270|Community 270]]
+- [[_COMMUNITY_Community 271|Community 271]]
+- [[_COMMUNITY_Community 272|Community 272]]
+- [[_COMMUNITY_Community 273|Community 273]]
+- [[_COMMUNITY_Community 274|Community 274]]
+- [[_COMMUNITY_Community 275|Community 275]]
+- [[_COMMUNITY_Community 276|Community 276]]
+- [[_COMMUNITY_Community 277|Community 277]]
+- [[_COMMUNITY_Community 278|Community 278]]
+- [[_COMMUNITY_Community 279|Community 279]]
+- [[_COMMUNITY_Community 280|Community 280]]
+- [[_COMMUNITY_Community 281|Community 281]]
+- [[_COMMUNITY_Community 282|Community 282]]
+- [[_COMMUNITY_Community 283|Community 283]]
+- [[_COMMUNITY_Community 284|Community 284]]
+- [[_COMMUNITY_Community 285|Community 285]]
+- [[_COMMUNITY_Community 286|Community 286]]
+- [[_COMMUNITY_Community 287|Community 287]]
+- [[_COMMUNITY_Community 288|Community 288]]
+- [[_COMMUNITY_Community 289|Community 289]]
+- [[_COMMUNITY_Community 290|Community 290]]
+- [[_COMMUNITY_Community 291|Community 291]]
+- [[_COMMUNITY_Community 292|Community 292]]
+- [[_COMMUNITY_Community 293|Community 293]]
+- [[_COMMUNITY_Community 294|Community 294]]
+- [[_COMMUNITY_Community 295|Community 295]]
+- [[_COMMUNITY_Community 296|Community 296]]
+- [[_COMMUNITY_Community 297|Community 297]]
+- [[_COMMUNITY_Community 298|Community 298]]
+- [[_COMMUNITY_Community 299|Community 299]]
+- [[_COMMUNITY_Community 300|Community 300]]
+- [[_COMMUNITY_Community 301|Community 301]]
+- [[_COMMUNITY_Community 302|Community 302]]
+- [[_COMMUNITY_Community 303|Community 303]]
+- [[_COMMUNITY_Community 304|Community 304]]
+- [[_COMMUNITY_Community 305|Community 305]]
+- [[_COMMUNITY_Community 306|Community 306]]
+- [[_COMMUNITY_Community 307|Community 307]]
+- [[_COMMUNITY_Community 308|Community 308]]
+- [[_COMMUNITY_Community 309|Community 309]]
+- [[_COMMUNITY_Community 310|Community 310]]
+- [[_COMMUNITY_Community 311|Community 311]]
+- [[_COMMUNITY_Community 312|Community 312]]
+- [[_COMMUNITY_Community 313|Community 313]]
+- [[_COMMUNITY_Community 314|Community 314]]
+- [[_COMMUNITY_Community 315|Community 315]]
+- [[_COMMUNITY_Community 316|Community 316]]
+- [[_COMMUNITY_Community 317|Community 317]]
+- [[_COMMUNITY_Community 318|Community 318]]
+- [[_COMMUNITY_Community 319|Community 319]]
+- [[_COMMUNITY_Community 320|Community 320]]
+- [[_COMMUNITY_Community 321|Community 321]]
+- [[_COMMUNITY_Community 322|Community 322]]
+- [[_COMMUNITY_Community 323|Community 323]]
+- [[_COMMUNITY_Community 324|Community 324]]
+- [[_COMMUNITY_Community 325|Community 325]]
+- [[_COMMUNITY_Community 326|Community 326]]
+- [[_COMMUNITY_Community 327|Community 327]]
+- [[_COMMUNITY_Community 328|Community 328]]
+- [[_COMMUNITY_Community 329|Community 329]]
+- [[_COMMUNITY_Community 330|Community 330]]
+- [[_COMMUNITY_Community 331|Community 331]]
+- [[_COMMUNITY_Community 332|Community 332]]
+- [[_COMMUNITY_Community 333|Community 333]]
+- [[_COMMUNITY_Community 334|Community 334]]
+- [[_COMMUNITY_Community 335|Community 335]]
+- [[_COMMUNITY_Community 336|Community 336]]
+- [[_COMMUNITY_Community 337|Community 337]]
+- [[_COMMUNITY_Community 338|Community 338]]
+- [[_COMMUNITY_Community 339|Community 339]]
+- [[_COMMUNITY_Community 340|Community 340]]
+- [[_COMMUNITY_Community 341|Community 341]]
+- [[_COMMUNITY_Community 342|Community 342]]
+- [[_COMMUNITY_Community 343|Community 343]]
+- [[_COMMUNITY_Community 344|Community 344]]
+- [[_COMMUNITY_Community 345|Community 345]]
+- [[_COMMUNITY_Community 346|Community 346]]
+- [[_COMMUNITY_Community 347|Community 347]]
+- [[_COMMUNITY_Community 348|Community 348]]
+- [[_COMMUNITY_Community 349|Community 349]]
+- [[_COMMUNITY_Community 350|Community 350]]
+- [[_COMMUNITY_Community 351|Community 351]]
+- [[_COMMUNITY_Community 352|Community 352]]
+- [[_COMMUNITY_Community 353|Community 353]]
+- [[_COMMUNITY_Community 354|Community 354]]
+- [[_COMMUNITY_Community 355|Community 355]]
+- [[_COMMUNITY_Community 356|Community 356]]
+- [[_COMMUNITY_Community 357|Community 357]]
+- [[_COMMUNITY_Community 358|Community 358]]
+- [[_COMMUNITY_Community 359|Community 359]]
+- [[_COMMUNITY_Community 360|Community 360]]
+- [[_COMMUNITY_Community 361|Community 361]]
+- [[_COMMUNITY_Community 362|Community 362]]
+- [[_COMMUNITY_Community 363|Community 363]]
+- [[_COMMUNITY_Community 364|Community 364]]
+- [[_COMMUNITY_Community 365|Community 365]]
+- [[_COMMUNITY_Community 366|Community 366]]
+- [[_COMMUNITY_Community 367|Community 367]]
+- [[_COMMUNITY_Community 368|Community 368]]
+- [[_COMMUNITY_Community 369|Community 369]]
+- [[_COMMUNITY_Community 370|Community 370]]
+- [[_COMMUNITY_Community 371|Community 371]]
+- [[_COMMUNITY_Community 372|Community 372]]
+- [[_COMMUNITY_Community 373|Community 373]]
+- [[_COMMUNITY_Community 374|Community 374]]
+- [[_COMMUNITY_Community 375|Community 375]]
+- [[_COMMUNITY_Community 376|Community 376]]
+- [[_COMMUNITY_Community 377|Community 377]]
+- [[_COMMUNITY_Community 378|Community 378]]
+- [[_COMMUNITY_Community 379|Community 379]]
+- [[_COMMUNITY_Community 380|Community 380]]
+- [[_COMMUNITY_Community 381|Community 381]]
+- [[_COMMUNITY_Community 382|Community 382]]
+- [[_COMMUNITY_Community 383|Community 383]]
+- [[_COMMUNITY_Community 384|Community 384]]
+- [[_COMMUNITY_Community 385|Community 385]]
+- [[_COMMUNITY_Community 386|Community 386]]
+- [[_COMMUNITY_Community 387|Community 387]]
+- [[_COMMUNITY_Community 388|Community 388]]
+- [[_COMMUNITY_Community 389|Community 389]]
+- [[_COMMUNITY_Community 390|Community 390]]
+- [[_COMMUNITY_Community 391|Community 391]]
+- [[_COMMUNITY_Community 392|Community 392]]
+- [[_COMMUNITY_Community 393|Community 393]]
+- [[_COMMUNITY_Community 394|Community 394]]
+- [[_COMMUNITY_Community 395|Community 395]]
+- [[_COMMUNITY_Community 396|Community 396]]
+- [[_COMMUNITY_Community 397|Community 397]]
+- [[_COMMUNITY_Community 398|Community 398]]
+- [[_COMMUNITY_Community 400|Community 400]]
+- [[_COMMUNITY_Community 401|Community 401]]
+- [[_COMMUNITY_Community 402|Community 402]]
+- [[_COMMUNITY_Community 403|Community 403]]
+- [[_COMMUNITY_Community 404|Community 404]]
+- [[_COMMUNITY_Community 405|Community 405]]
+- [[_COMMUNITY_Community 406|Community 406]]
+- [[_COMMUNITY_Community 409|Community 409]]
+- [[_COMMUNITY_Community 410|Community 410]]
+- [[_COMMUNITY_Community 411|Community 411]]
+- [[_COMMUNITY_Community 412|Community 412]]
+- [[_COMMUNITY_Community 413|Community 413]]
+- [[_COMMUNITY_Community 414|Community 414]]
+- [[_COMMUNITY_Community 415|Community 415]]
+- [[_COMMUNITY_Community 416|Community 416]]
+- [[_COMMUNITY_Community 417|Community 417]]
+- [[_COMMUNITY_Community 418|Community 418]]
+- [[_COMMUNITY_Community 419|Community 419]]
+- [[_COMMUNITY_Community 420|Community 420]]
+- [[_COMMUNITY_Community 421|Community 421]]
+- [[_COMMUNITY_Community 422|Community 422]]
+- [[_COMMUNITY_Community 423|Community 423]]
+- [[_COMMUNITY_Community 424|Community 424]]
+- [[_COMMUNITY_Community 425|Community 425]]
+- [[_COMMUNITY_Community 426|Community 426]]
+- [[_COMMUNITY_Community 427|Community 427]]
+- [[_COMMUNITY_Community 428|Community 428]]
+- [[_COMMUNITY_Community 429|Community 429]]
+- [[_COMMUNITY_Community 430|Community 430]]
+- [[_COMMUNITY_Community 431|Community 431]]
+- [[_COMMUNITY_Community 432|Community 432]]
+- [[_COMMUNITY_Community 433|Community 433]]
+- [[_COMMUNITY_Community 434|Community 434]]
+- [[_COMMUNITY_Community 435|Community 435]]
+- [[_COMMUNITY_Community 436|Community 436]]
+- [[_COMMUNITY_Community 437|Community 437]]
+- [[_COMMUNITY_Community 438|Community 438]]
+- [[_COMMUNITY_Community 439|Community 439]]
+- [[_COMMUNITY_Community 440|Community 440]]
+- [[_COMMUNITY_Community 441|Community 441]]
+- [[_COMMUNITY_Community 442|Community 442]]
+- [[_COMMUNITY_Community 443|Community 443]]
+- [[_COMMUNITY_Community 444|Community 444]]
+- [[_COMMUNITY_Community 445|Community 445]]
+- [[_COMMUNITY_Community 446|Community 446]]
+- [[_COMMUNITY_Community 447|Community 447]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `F()` - 70 edges
-2. `PreprocessedCoRalDataset` - 69 edges
+1. `PreprocessedCoRalDataset` - 69 edges
+2. `F()` - 68 edges
 3. `e()` - 53 edges
 4. `t()` - 52 edges
 5. `CoRalDataset` - 46 edges
@@ -266,95 +449,95 @@
 - `PreprocessedCoRalDataset` --uses--> `Shared infrastructure for HF baseline training scripts (Wav2Vec2, Whisper).`  [INFERRED]
   src/danish_asr/data.py → scripts/hpc/train_common.py
 
-## Communities
+## Communities (448 total, 220 thin omitted)
 
 ### Community 0 - "Community 0"
-Cohesion: 0.02
-Nodes (283): _(), a(), Aa(), Ac(), Ae(), ai(), an(), ao() (+275 more)
+Cohesion: 0.03
+Nodes (61): Ae(), ai(), ap(), Bc(), Ca(), ci(), constructor(), di() (+53 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (192): CYTHON_MAYBE_UNUSED_VAR(), __Pyx_AddTraceback(), __pyx_bisect_code_objects(), __Pyx_CalculateMetaclass(), __Pyx_call_destructor(), __Pyx_check_single_interpreter(), __Pyx_CheckKeywordStrings(), __Pyx_CLineForTraceback() (+184 more)
+Cohesion: 0.03
+Nodes (50): __Pyx_CalculateMetaclass(), __Pyx_call_destructor(), __Pyx_check_single_interpreter(), __Pyx_copy_spec_to_module(), __Pyx__Coroutine_New(), __Pyx__Coroutine_NewInit(), __Pyx_Coroutine_traverse(), __Pyx_Coroutine_traverse_excstate() (+42 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (141): build_hf_text_lm_corpus(), build_lm_corpus_from_parquet(), build_pyctcdecode_labels(), chunked(), collate_decode_records(), CorpusStats, _dataset_name(), decode_ctc_logits() (+133 more)
+Cohesion: 0.14
+Nodes (33): Any, build_hf_text_lm_corpus(), build_lm_corpus_from_parquet(), CorpusStats, _dataset_name(), _hash_text(), infer_split_from_eval_config(), iter_fairseq2_rows() (+25 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.04
-Nodes (65): collate_fn(), CoRalDataModule, CoRalDataset, _pad_1d_tensors(), PreprocessedCoRalDataset, CoRal Danish ASR dataset and data module., Pad variable-length 1D tensors to uniform length.      Returns (stacked_tensor,, Custom collate function for variable-length audio. (+57 more)
+Cohesion: 0.14
+Nodes (16): CoRalDataset, CoRal Danish speech dataset wrapper.      Wraps HuggingFace datasets for CoRal r, Dataset, _make_fake_hf_dataset(), Create a minimal list-of-dicts that mimics a HuggingFace dataset split., Tests for Whisper processor and tokenizer integration., Processor returning input_features should populate that key., Tokenizer should produce labels key with token IDs. (+8 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.03
-Nodes (69): log_gpu_info(), log_line_to_wandb(), log_system_info(), Shared infrastructure for HPC scripts: logging, paths, environment helpers., Log hostname, user, Python version, CUDA_VISIBLE_DEVICES, LSB_JOBID, disk space., Parse a fairseq2 output line and log matching metrics to W&B., Log torch CUDA availability, device names, and VRAM., Configure loguru with console (INFO) and file (DEBUG) sinks.      Returns the pa (+61 more)
+Cohesion: 0.11
+Nodes (30): log_gpu_info(), Shared infrastructure for HPC scripts: logging, paths, environment helpers., Log torch CUDA availability, device names, and VRAM., Set HF_HOME, FAIRSEQ2_CACHE_DIR, TMPDIR for HPC jobs., setup_hpc_environment(), build_datasets(), CTCDataCollator, finish_wandb() (+22 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.04
-Nodes (65): IsNan(), BOOST_AUTO_TEST_CASE(), Run(), BOOST_AUTO_TEST_CASE(), BOOST_AUTO_TEST_CASE(), AdvanceOrThrow(), Close(), CreateOrThrow() (+57 more)
+Cohesion: 0.09
+Nodes (19): Run(), AdvanceOrThrow(), Close(), CreateOrThrow(), EndOfFileException(), ErsatzPRead(), ErsatzPWrite(), GuardLarge() (+11 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.04
-Nodes (55): convert_split(), main(), parse_args(), process_audio(), Unified preprocessing for CoRal-v3: fairseq2 + universal Parquet formats.  Resam, Resample to 16kHz and FLAC-encode once.      Returns:         (flac_bytes, audio, Write rows to a fairseq2-format Parquet file., Write rows to a universal-format Parquet file. (+47 more)
+Cohesion: 0.19
+Nodes (9): process_audio(), Resample audio to 16kHz and encode as FLAC.      Returns (int8_array, audio_size, _make_audio_dict(), Create a fake HF audio dict., FLAC encoding should produce decodable audio with correct length and close value, TestProcessAudio, _make_audio_dict(), Create a fake HF audio dict. (+1 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.04
-Nodes (48): MergeWorker, ReunifyBackoff(), BOOST_AUTO_TEST_CASE(), CheckOutput, WriteBackoffs, WriteInput, CompareFiles, MergeVocab() (+40 more)
+Cohesion: 0.12
+Nodes (19): BackoffMessages, BlankManager, BuildTrie(), FindBlanks, Gram(), InitializeFromARPA(), PopulateUnigramWeights(), ReadOrThrow() (+11 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.05
-Nodes (52): BignumDtoa(), BignumToFixed(), EstimatePower(), FixupMultiply10(), GenerateCountedDigits(), GenerateShortestDigits(), InitialScaledStartValues(), InitialScaledStartValuesNegativeExponentNegativePower() (+44 more)
+Cohesion: 0.10
+Nodes (37): BignumDtoa(), BignumToFixed(), EstimatePower(), FixupMultiply10(), GenerateCountedDigits(), GenerateShortestDigits(), InitialScaledStartValues(), InitialScaledStartValuesNegativeExponentNegativePower() (+29 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.06
-Nodes (61): A(), add(), At(), be(), Bt(), ce(), constructor(), Ct() (+53 more)
+Nodes (62): A(), add(), At(), be(), Bt(), ce(), constructor(), Ct() (+54 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.04
-Nodes (34): double_conversion(), SetSpecial(), Add(), ComputeRenumbering(), ConfigureEnumerate(), FinishedLoading(), GenericFinished(), HashForVocab() (+26 more)
+Cohesion: 0.11
+Nodes (17): SetSpecial(), Add(), ComputeRenumbering(), ConfigureEnumerate(), FinishedLoading(), GenericFinished(), HashForVocab(), Insert() (+9 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.05
-Nodes (43): main(), ParseBitCount(), ParseFileList(), ParseFloat(), ParseUInt(), ProbingQuantizationUnsupported(), Usage(), main() (+35 more)
+Cohesion: 0.15
+Nodes (10): ReadEnd(), ActivateLowerMiddle, ActivateUnigram, ApplyBuild(), DispatchBuild(), HashedSearch<BackoffValue>, HashedSearch<RestValue>, InitializeFromARPA() (+2 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.05
-Nodes (47): _backup_score_file(), check_prerequisites(), _get_score_file(), _log_workspace_snapshot(), main(), _MetricParser, _next_backup_path(), Step 4: Evaluation wrapper for omniASR on HPC.  Runs the omniASR eval recipe on (+39 more)
+Cohesion: 0.09
+Nodes (34): float, log_line_to_wandb(), Parse a fairseq2 output line and log matching metrics to W&B., _backup_score_file(), check_prerequisites(), _get_score_file(), _log_workspace_snapshot(), main() (+26 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.05
-Nodes (37): compute_cer(), compute_metrics(), compute_wer(), ASR evaluation metrics (WER, CER)., Compute Character Error Rate.      Args:         predictions: Model transcriptio, Compute all ASR metrics., Compute Word Error Rate.      Args:         predictions: Model transcriptions, build_model() (+29 more)
+Cohesion: 0.14
+Nodes (16): compute_cer(), compute_metrics(), compute_wer(), ASR evaluation metrics (WER, CER)., Compute Character Error Rate.      Args:         predictions: Model transcriptio, Compute all ASR metrics., Compute Word Error Rate.      Args:         predictions: Model transcriptions, Tests for ASR metrics. (+8 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.06
-Nodes (44): FinishFile(), GrowForSearch(), InitializeBinary(), IsBinaryFormat(), MapFile(), MatchCheck(), ReadHeader(), RecognizeBinary() (+36 more)
+Nodes (46): FinishFile(), GrowForSearch(), InitializeBinary(), IsBinaryFormat(), MapFile(), MatchCheck(), ReadHeader(), RecognizeBinary() (+38 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.06
-Nodes (43): main(), prepare_config(), Prepare a Fairseq2 eval config that opens a one-corpus parquet root.  Fairseq2's, Return a full summary TSV to filter for a subset config.      Existing subset co, _resolve_project_path(), _safe_symlink(), _source_summary_for_subset(), _write_filtered_summary() (+35 more)
+Cohesion: 0.15
+Nodes (26): _build_html(), _cell_class(), _extract_table(), _find_chrome(), _is_separator_row(), main(), parse_args(), Render a results table from docs/evaluation-results.md to HTML or PNG.  Examples (+18 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.08
+Cohesion: 0.09
 Nodes (48): build_diagnostics(), _checkpoint_exists(), _emit_coral_subsets(), _emit_models(), _emit_my_splits(), _emit_shell(), _expand(), _fairseq2_cache_roots() (+40 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.07
-Nodes (43): _age_group(), bounded_error_rate(), convert_numeral_to_words(), CoRalBenchmarkExample, _dialect(), _empty_filter_stats(), _example_duration_seconds(), example_group_metadata() (+35 more)
+Cohesion: 0.08
+Nodes (41): _age_group(), bounded_error_rate(), convert_numeral_to_words(), CoRalBenchmarkExample, _dialect(), _empty_filter_stats(), _example_duration_seconds(), example_group_metadata() (+33 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.11
-Nodes (36): Advance(), AdvanceToNonspace(), ConsumeFirstCharacter(), ConsumeSubString(), ConsumeSubStringImpl(), IsCharacterDigitForRadix(), IsDecimalDigitForRadix(), isDigit() (+28 more)
+Cohesion: 0.09
+Nodes (44): Advance(), AdvanceToNonspace(), ConsumeFirstCharacter(), ConsumeSubString(), ConsumeSubStringImpl(), IsCharacterDigitForRadix(), IsDecimalDigitForRadix(), isDigit() (+36 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.06
-Nodes (20): Arc, Evaluate(), LowerBound(), Vertex, BZip, Complete, Current(), DetectCompressedMagic() (+12 more)
+Cohesion: 0.09
+Nodes (15): BZip, Complete, DetectCompressedMagic(), DetectMagic(), GZip, IStreamReader, ReadCompressed(), ReadFactory() (+7 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.13
 Nodes (32): ArtifactVersionRow, audit(), _build_arg_parser(), build_artifact_report(), build_run_file_report(), _bytes_to_gib(), collect_artifact_rows(), collect_run_file_rows() (+24 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.09
-Nodes (20): Immediate, main(), ParallelTestRun(), PrefetchQueue, Size(), Test(), TestRun(), URandom (+12 more)
+Cohesion: 0.18
+Nodes (13): Test(), CPUTime(), DoubleSec(), GetWall(), GuessPhysicalMemory(), ParseNum(), PrintUsage(), RecordStart (+5 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.15
@@ -365,12 +548,12 @@ Cohesion: 0.08
 Nodes (25): check_gpu(), clean_all(), clean_build(), clean_outputs(), clean_pyc(), clean_test(), dtu_vpn(), env_info() (+17 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.1
+Cohesion: 0.10
 Nodes (23): _available_llm_hardware(), _has_module(), hpc_smoke(), hpc_sweep(), omniasr(), omniasr_eval(), omniasr_sweep(), Training and hyperparameter tuning tasks. (+15 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.12
-Nodes (13): Callback, Interpolate(), OutputProbBackoff, OutputQ, CountText(), InitialProbabilities(), InterpolateProbabilities(), Master (+5 more)
+Cohesion: 0.23
+Nodes (10): Interpolate(), CountText(), InitialProbabilities(), InterpolateProbabilities(), Master, MaximumLazyInput(), Pipeline(), PrintStatistics() (+2 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.14
@@ -385,8 +568,8 @@ Cohesion: 0.19
 Nodes (10): _DummyCTCModel, _DummyProcessor, _DummySeq2SeqInner, _DummySeq2SeqModel, _DummyTokenizer, Tests for the training module., test_ctc_build_processor_uses_vocab_asset(), test_ctc_validation_prefers_normalized_references() (+2 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.19
-Nodes (16): cache_dir_for_uri(), main(), _normalise_uri(), parse_args(), Resolve an already-cached fairseq2 asset to a local path without downloading.  T, Mirror fairseq2's cache-key URI normalisation., Return the fairseq2 content-addressed cache directory for ``uri``., Resolve a cached fairseq2 asset URI without triggering a download. (+8 more)
+Cohesion: 0.14
+Nodes (27): cache_dir_for_uri(), main(), _normalise_uri(), parse_args(), Resolve an already-cached fairseq2 asset to a local path without downloading.  T, Mirror fairseq2's cache-key URI normalisation., Mirror fairseq2's cache-key URI normalisation., Return the fairseq2 content-addressed cache directory for ``uri``. (+19 more)
 
 ### Community 30 - "Community 30"
 Cohesion: 0.15
@@ -397,7 +580,7 @@ Cohesion: 0.21
 Nodes (12): best(), _build_result(), _find_best_run(), _get_default_entity_project(), _get_summary_metric(), _is_better_value(), _normalize_sweep_id(), Utilities for working with W&B sweeps.  Provides a CLI to identify the best run (+4 more)
 
 ### Community 32 - "Community 32"
-Cohesion: 0.2
+Cohesion: 0.20
 Nodes (13): api(), build(), build_cuda(), check_docker_available(), clean(), Docker container and image management tasks., Check if Docker is installed and running., Build docker images (CPU versions). (+5 more)
 
 ### Community 33 - "Community 33"
@@ -413,12 +596,12 @@ Cohesion: 0.21
 Nodes (9): BaseInit(), BaseSize(), BitPackedMiddle(), BitPackedMiddle<ArrayBhiksha>, BitPackedMiddle<DontBhiksha>, Find(), FindBitPacked(), KeyAccessor (+1 more)
 
 ### Community 36 - "Community 36"
-Cohesion: 0.24
-Nodes (9): normalize_coral_text(), normalize_ctc_text(), Shared text normalization helpers for ASR baselines., Normalize text following CoRal benchmark conventions.      Applied before model-, Normalize text for CTC training and evaluation.      Keep punctuation as-is for, Tests for text normalization helpers., test_normalize_coral_text_applies_nfkc_and_substitutions(), test_normalize_coral_text_removes_fillers_and_normalizes_spaces() (+1 more)
+Cohesion: 0.12
+Nodes (19): normalize_coral_text(), normalize_ctc_text(), Shared text normalization helpers for ASR baselines., Normalize text following CoRal benchmark conventions.      Applied before model-, Normalize text for CTC training and evaluation.      Keep punctuation as-is for, build_ctc_vocab(), iter_training_texts(), main() (+11 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.36
-Nodes (9): FastFixedDtoa(), FillDigits32(), FillDigits32FixedLength(), FillDigits64(), FillDigits64FixedLength(), FillFractionals(), RoundUp(), TrimZeros() (+1 more)
+Cohesion: 0.03
+Nodes (65): |, 0, 1, ½, 2, 3, 4, 5 (+57 more)
 
 ### Community 38 - "Community 38"
 Cohesion: 0.36
@@ -464,10 +647,6 @@ Nodes (4): CollapseStream, FindDifference(), Run(), StatCollector
 Cohesion: 0.25
 Nodes (4): Derivatives(), BOOST_AUTO_TEST_CASE(), MockInstances, TuneWeights()
 
-### Community 49 - "Community 49"
-Cohesion: 0.33
-Nodes (2): ErrnoException(), HandleStrerror()
-
 ### Community 50 - "Community 50"
 Cohesion: 0.43
 Nodes (3): MakeBins(), Train(), TrainProb()
@@ -485,1066 +664,567 @@ Cohesion: 0.53
 Nodes (3): Apply(), Sink(), SinkProbs()
 
 ### Community 56 - "Community 56"
-Cohesion: 0.4
+Cohesion: 0.40
 Nodes (3): Documentation building and serving tasks., Serve documentation locally., serve()
 
 ### Community 57 - "Community 57"
-Cohesion: 0.5
+Cohesion: 0.50
 Nodes (4): _has_module(), pull_llm(), Asset management tasks (model checkpoint pre-download)., Pre-download omniASR_LLM_300M_v2 or omniASR_LLM_1B_v2 to FAIRSEQ2_CACHE_DIR.
 
 ### Community 58 - "Community 58"
-Cohesion: 0.6
+Cohesion: 0.60
 Nodes (3): MurmurHash64A(), MurmurHash64B(), MurmurHashNativeBackend()
 
-### Community 59 - "Community 59"
-Cohesion: 0.4
-Nodes (2): BitPackingSanity(), BOOST_AUTO_TEST_CASE()
-
 ### Community 60 - "Community 60"
-Cohesion: 0.5
+Cohesion: 0.50
 Nodes (3): BOOST_AUTO_TEST_CASE(), KeepCopy, WriteInput
 
 ### Community 61 - "Community 61"
-Cohesion: 0.6
+Cohesion: 0.60
 Nodes (3): main(), SizeNotify, SizeOption()
 
 ### Community 63 - "Community 63"
-Cohesion: 0.5
+Cohesion: 0.50
 Nodes (3): load_module_from_file(), Invoke tasks for Danish ASR.  Tasks are organized into namespaces for better org, Load a module from a file path.
-
-### Community 64 - "Community 64"
-Cohesion: 0.67
-Nodes (1): build_ext
 
 ### Community 65 - "Community 65"
 Cohesion: 0.83
 Nodes (3): Convert8DigitsSSE2(), ShiftDigits_SSE2(), ToString()
 
-### Community 67 - "Community 67"
-Cohesion: 0.5
-Nodes (1): Reader
-
 ### Community 68 - "Community 68"
 Cohesion: 0.83
 Nodes (3): BOOST_AUTO_TEST_CASE(), TestCorners(), TestEqual()
-
-### Community 69 - "Community 69"
-Cohesion: 0.67
-Nodes (2): IsLineEnd(), ReadMultiple()
 
 ### Community 70 - "Community 70"
 Cohesion: 0.83
 Nodes (3): main(), ParseDiscountFallback(), ParsePruning()
 
-### Community 71 - "Community 71"
-Cohesion: 0.67
-Nodes (2): PrintLead(), Run()
-
-### Community 72 - "Community 72"
-Cohesion: 0.67
-Nodes (2): SizeNotify, SizeOption()
-
 ### Community 73 - "Community 73"
 Cohesion: 0.83
 Nodes (3): BOOST_AUTO_TEST_CASE(), CheckEncodeDecode(), ExhaustiveTest()
 
-### Community 74 - "Community 74"
-Cohesion: 0.67
-Nodes (2): Register danish_asr asset cards (datasets) with fairseq2., setup_fairseq2_extension()
-
-### Community 75 - "Community 75"
-Cohesion: 0.67
-Nodes (1): Regression test: LLM eval configs must have family+arch whenever path is set.  f
-
-### Community 76 - "Community 76"
-Cohesion: 0.67
-Nodes (1): Upload finetuned model checkpoints to W&B as artifacts.  Run from project root (
-
 ### Community 77 - "Community 77"
-Cohesion: 0.67
-Nodes (1): Pre-download omniASR LLM V2 checkpoint + tokenizer to FAIRSEQ2_CACHE_DIR.  Run o
-
-### Community 78 - "Community 78"
-Cohesion: 0.67
-Nodes (1): Patch omnilingual-asr wer_calculator.py to handle empty CTC hypotheses.  Fixes k
-
-### Community 79 - "Community 79"
-Cohesion: 0.67
-Nodes (1): Legacy helper to filter language_distribution_0.tsv to one CoRal-v3 subset.  Dep
-
-### Community 80 - "Community 80"
-Cohesion: 1.0
-Nodes (2): BOOST_AUTO_TEST_CASE(), RangeFromArray()
-
-### Community 81 - "Community 81"
-Cohesion: 1.0
-Nodes (2): Copy(), main()
-
-### Community 82 - "Community 82"
-Cohesion: 1.0
-Nodes (2): BOOST_AUTO_TEST_CASE(), Entry64()
-
-### Community 83 - "Community 83"
-Cohesion: 1.0
-Nodes (2): BOOST_AUTO_TEST_CASE(), Putter()
-
-### Community 86 - "Community 86"
-Cohesion: 1.0
-Nodes (2): BOOST_AUTO_TEST_CASE(), CheckAnswers
-
-### Community 88 - "Community 88"
-Cohesion: 1.0
-Nodes (2): main(), MungeWeightArgs()
-
-### Community 89 - "Community 89"
-Cohesion: 1.0
-Nodes (1): LM-related helper scripts.
-
-### Community 116 - "Community 116"
-Cohesion: 1.0
-Nodes (1): True once the first warning occurrence has been seen.
-
-### Community 120 - "Community 120"
-Cohesion: 1.0
-Nodes (1): Create an OmniASR inference pipeline for CTC decoding.
-
-### Community 121 - "Community 121"
-Cohesion: 1.0
-Nodes (1): Read UTF-8 text lines without trailing newlines.
-
-### Community 122 - "Community 122"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
-
-### Community 123 - "Community 123"
-Cohesion: 1.0
-Nodes (1): Construct a pyctcdecode decoder lazily.
-
-### Community 124 - "Community 124"
-Cohesion: 1.0
-Nodes (1): Create an OmniASR inference pipeline for CTC decoding.
-
-### Community 125 - "Community 125"
-Cohesion: 1.0
-Nodes (1): Yield fixed-size chunks from a sequence.
-
-### Community 126 - "Community 126"
-Cohesion: 1.0
-Nodes (1): Construct a pyctcdecode decoder lazily.
-
-### Community 127 - "Community 127"
-Cohesion: 1.0
-Nodes (1): Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con
-
-### Community 128 - "Community 128"
-Cohesion: 1.0
-Nodes (1): Construct a pyctcdecode decoder lazily.
-
-### Community 129 - "Community 129"
-Cohesion: 1.0
-Nodes (1): Compute simple WER/CER summaries from aligned prediction/reference lists.
-
-### Community 130 - "Community 130"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
-
-### Community 131 - "Community 131"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
-
-### Community 132 - "Community 132"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 133 - "Community 133"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
-
-### Community 134 - "Community 134"
-Cohesion: 1.0
-Nodes (1): Return preflight errors for the requested eval method.
-
-### Community 135 - "Community 135"
-Cohesion: 1.0
-Nodes (1): Get the best available device. Priority: CUDA > MPS > CPU.
-
-### Community 136 - "Community 136"
-Cohesion: 1.0
-Nodes (1): Build pyctcdecode labels in the exact OmniASR logit order.
-
-### Community 137 - "Community 137"
-Cohesion: 1.0
-Nodes (1): Build pyctcdecode labels in the exact OmniASR logit order.
-
-### Community 138 - "Community 138"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
-
-### Community 139 - "Community 139"
-Cohesion: 1.0
-Nodes (1): Load a custom OmniASR CTC checkpoint using fairseq2's registered family.
+Cohesion: 0.15
+Nodes (15): ASRInferencePipeline, load_custom_omniasr_ctc_model(), make_inference_pipeline(), Load a custom OmniASR CTC checkpoint using fairseq2's registered family., Load a custom OmniASR CTC checkpoint using fairseq2's registered family., Create an OmniASR inference pipeline for CTC decoding., Create an OmniASR inference pipeline for CTC decoding., Resolve a dtype string with a CPU-safe fallback. (+7 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 1.0
-Nodes (1): Read UTF-8 text lines without trailing newlines.
-
-### Community 141 - "Community 141"
-Cohesion: 1.0
-Nodes (1): Yield fixed-size chunks from a sequence.
-
-### Community 142 - "Community 142"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
-
-### Community 143 - "Community 143"
-Cohesion: 1.0
-Nodes (1): Write UTF-8 text lines with trailing newlines.
-
-### Community 144 - "Community 144"
-Cohesion: 1.0
-Nodes (1): Construct a pyctcdecode decoder lazily.
-
-### Community 145 - "Community 145"
-Cohesion: 1.0
-Nodes (1): Compute simple WER/CER summaries from aligned prediction/reference lists.
-
-### Community 146 - "Community 146"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
-
-### Community 147 - "Community 147"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
+Cohesion: 0.11
+Nodes (58): Ac(), ar(), as(), b(), Br(), Cc(), cp(), dp() (+50 more)
 
 ### Community 148 - "Community 148"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 149 - "Community 149"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
-
-### Community 150 - "Community 150"
-Cohesion: 1.0
-Nodes (1): Return a full summary TSV to filter for a subset config.      Existing subset co
-
-### Community 151 - "Community 151"
-Cohesion: 1.0
-Nodes (1): Pin model and dataset caches to the project drive.      This keeps large Hugging
-
-### Community 152 - "Community 152"
-Cohesion: 1.0
-Nodes (1): Get the best available device. Priority: CUDA > MPS > CPU.
-
-### Community 153 - "Community 153"
-Cohesion: 1.0
-Nodes (1): Load the OmniASR tokenizer, preferring an explicit or cached local model file.
-
-### Community 154 - "Community 154"
-Cohesion: 1.0
-Nodes (1): Build pyctcdecode labels in the exact OmniASR logit order.
-
-### Community 155 - "Community 155"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
-
-### Community 156 - "Community 156"
-Cohesion: 1.0
-Nodes (1): Create an OmniASR inference pipeline for CTC decoding.
-
-### Community 157 - "Community 157"
-Cohesion: 1.0
-Nodes (1): Create an OmniASR inference pipeline for CTC decoding.
-
-### Community 158 - "Community 158"
-Cohesion: 1.0
-Nodes (1): Yield fixed-size chunks from a sequence.
-
-### Community 159 - "Community 159"
-Cohesion: 1.0
-Nodes (1): Read UTF-8 text lines without trailing newlines.
-
-### Community 160 - "Community 160"
-Cohesion: 1.0
-Nodes (1): Write UTF-8 text lines with trailing newlines.
-
-### Community 161 - "Community 161"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 162 - "Community 162"
-Cohesion: 1.0
-Nodes (1): Construct a pyctcdecode decoder lazily.
-
-### Community 163 - "Community 163"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
-
-### Community 164 - "Community 164"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 165 - "Community 165"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
-
-### Community 166 - "Community 166"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 167 - "Community 167"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
-
-### Community 168 - "Community 168"
-Cohesion: 1.0
-Nodes (1): Return a full summary TSV to filter for a subset config.      Existing subset co
-
-### Community 169 - "Community 169"
-Cohesion: 1.0
-Nodes (1): Get the best available device. Priority: CUDA > MPS > CPU.
-
-### Community 170 - "Community 170"
-Cohesion: 1.0
-Nodes (1): Build a de-duplicated text LM corpus from one or more Hugging Face text datasets
-
-### Community 171 - "Community 171"
-Cohesion: 1.0
-Nodes (1): Write normalized LM text, one line per example.
-
-### Community 172 - "Community 172"
-Cohesion: 1.0
-Nodes (1): Write corpus stats as pretty JSON.
-
-### Community 173 - "Community 173"
-Cohesion: 1.0
-Nodes (1): Load a small YAML config file.
-
-### Community 174 - "Community 174"
-Cohesion: 1.0
-Nodes (1): Find a cached tokenizer model file using the asset card basename.
-
-### Community 175 - "Community 175"
-Cohesion: 1.0
-Nodes (1): Load the OmniASR tokenizer, preferring an explicit or cached local model file.
-
-### Community 176 - "Community 176"
-Cohesion: 1.0
-Nodes (1): Build pyctcdecode labels in the exact OmniASR logit order.
-
-### Community 177 - "Community 177"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
-
-### Community 178 - "Community 178"
-Cohesion: 1.0
-Nodes (1): Load a custom OmniASR CTC checkpoint using fairseq2's registered family.
-
-### Community 179 - "Community 179"
-Cohesion: 1.0
-Nodes (1): Yield fixed-size chunks from a sequence.
-
-### Community 180 - "Community 180"
-Cohesion: 1.0
-Nodes (1): Write UTF-8 text lines with trailing newlines.
-
-### Community 181 - "Community 181"
-Cohesion: 1.0
-Nodes (1): Write UTF-8 text lines with trailing newlines.
-
-### Community 182 - "Community 182"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
-
-### Community 183 - "Community 183"
-Cohesion: 1.0
-Nodes (1): Construct a pyctcdecode decoder lazily.
-
-### Community 184 - "Community 184"
-Cohesion: 1.0
-Nodes (1): Compute simple WER summary from aligned prediction/reference lists.
-
-### Community 185 - "Community 185"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
+Cohesion: 0.08
+Nodes (46): CYTHON_MAYBE_UNUSED_VAR(), __Pyx_AddTraceback(), __pyx_bisect_code_objects(), __Pyx_CreateCodeObjectForTraceback(), __pyx_f_5kenlm_as_str(), __pyx_find_code_object(), __pyx_gb_5kenlm_5Model_10generator(), __pyx_insert_code_object() (+38 more)
 
 ### Community 186 - "Community 186"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
-
-### Community 187 - "Community 187"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
-
-### Community 188 - "Community 188"
-Cohesion: 1.0
-Nodes (1): Return preflight errors for the requested eval method.
-
-### Community 189 - "Community 189"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
-
-### Community 190 - "Community 190"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
-
-### Community 191 - "Community 191"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 192 - "Community 192"
-Cohesion: 1.0
-Nodes (1): Compact statistics for an LM text build.
-
-### Community 193 - "Community 193"
-Cohesion: 1.0
-Nodes (1): Decoded hypothesis with reference metadata.
-
-### Community 194 - "Community 194"
-Cohesion: 1.0
-Nodes (1): Normalize transcript text for LM training without changing Danish orthography.
-
-### Community 195 - "Community 195"
-Cohesion: 1.0
-Nodes (1): Parse fairseq2 split names such as ``test`` or ``test_coral_v3_read_aloud``.
-
-### Community 196 - "Community 196"
-Cohesion: 1.0
-Nodes (1): Yield rows from fairseq2 parquet shards for the requested corpora/split.
-
-### Community 197 - "Community 197"
-Cohesion: 1.0
-Nodes (1): Build a deterministic LM text corpus from fairseq2 parquet transcripts.
-
-### Community 198 - "Community 198"
-Cohesion: 1.0
-Nodes (1): Build a de-duplicated text LM corpus from one or more Hugging Face text datasets
-
-### Community 199 - "Community 199"
-Cohesion: 1.0
-Nodes (1): Write normalized LM text, one line per example.
-
-### Community 200 - "Community 200"
-Cohesion: 1.0
-Nodes (1): Write corpus stats as pretty JSON.
-
-### Community 201 - "Community 201"
-Cohesion: 1.0
-Nodes (1): Find a cached tokenizer model file using the asset card basename.
-
-### Community 202 - "Community 202"
-Cohesion: 1.0
-Nodes (1): Load the OmniASR tokenizer, preferring an explicit or cached local model file.
-
-### Community 203 - "Community 203"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
-
-### Community 204 - "Community 204"
-Cohesion: 1.0
-Nodes (1): Load a custom OmniASR CTC checkpoint using fairseq2's registered family.
-
-### Community 205 - "Community 205"
-Cohesion: 1.0
-Nodes (1): Create an OmniASR inference pipeline for CTC decoding.
-
-### Community 206 - "Community 206"
-Cohesion: 1.0
-Nodes (1): Read UTF-8 text lines without trailing newlines.
-
-### Community 207 - "Community 207"
-Cohesion: 1.0
-Nodes (1): Write UTF-8 text lines with trailing newlines.
-
-### Community 208 - "Community 208"
-Cohesion: 1.0
-Nodes (1): Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con
-
-### Community 209 - "Community 209"
-Cohesion: 1.0
-Nodes (1): Compute simple WER summary from aligned prediction/reference lists.
-
-### Community 210 - "Community 210"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
-
-### Community 211 - "Community 211"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
-
-### Community 212 - "Community 212"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 213 - "Community 213"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
-
-### Community 214 - "Community 214"
-Cohesion: 1.0
-Nodes (1): Build a de-duplicated text LM corpus from one or more Hugging Face text datasets
-
-### Community 215 - "Community 215"
-Cohesion: 1.0
-Nodes (1): Write normalized LM text, one line per example.
-
-### Community 216 - "Community 216"
-Cohesion: 1.0
-Nodes (1): Write corpus stats as pretty JSON.
-
-### Community 217 - "Community 217"
-Cohesion: 1.0
-Nodes (1): Load a small YAML config file.
-
-### Community 218 - "Community 218"
-Cohesion: 1.0
-Nodes (1): Build pyctcdecode labels in the exact OmniASR logit order.
-
-### Community 219 - "Community 219"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
-
-### Community 220 - "Community 220"
-Cohesion: 1.0
-Nodes (1): Build pyctcdecode labels in the exact OmniASR logit order.
-
-### Community 221 - "Community 221"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
-
-### Community 222 - "Community 222"
-Cohesion: 1.0
-Nodes (1): Write UTF-8 text lines with trailing newlines.
-
-### Community 223 - "Community 223"
-Cohesion: 1.0
-Nodes (1): Create an OmniASR inference pipeline for CTC decoding.
-
-### Community 224 - "Community 224"
-Cohesion: 1.0
-Nodes (1): Yield fixed-size chunks from a sequence.
-
-### Community 225 - "Community 225"
-Cohesion: 1.0
-Nodes (1): Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con
-
-### Community 226 - "Community 226"
-Cohesion: 1.0
-Nodes (1): Compute simple WER summary from aligned prediction/reference lists.
-
-### Community 227 - "Community 227"
-Cohesion: 1.0
-Nodes (1): Resolve a dtype string with a CPU-safe fallback.
-
-### Community 228 - "Community 228"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
-
-### Community 229 - "Community 229"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
-
-### Community 230 - "Community 230"
-Cohesion: 1.0
-Nodes (1): Exclusion is enforced on normalized text, so casing / URLs / metadata don't bypa
-
-### Community 231 - "Community 231"
-Cohesion: 1.0
-Nodes (1): Build a de-duplicated text LM corpus from Hugging Face datasets.      This is in
-
-### Community 232 - "Community 232"
-Cohesion: 1.0
-Nodes (1): Write normalized LM text, one line per example.
-
-### Community 233 - "Community 233"
-Cohesion: 1.0
-Nodes (1): Write corpus stats as pretty JSON.
-
-### Community 234 - "Community 234"
-Cohesion: 1.0
-Nodes (1): Load a small YAML config file.
-
-### Community 235 - "Community 235"
-Cohesion: 1.0
-Nodes (1): Find a cached tokenizer model file using the asset card basename.
-
-### Community 236 - "Community 236"
-Cohesion: 1.0
-Nodes (1): Load the OmniASR tokenizer, preferring an explicit or cached local model file.
-
-### Community 237 - "Community 237"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
-
-### Community 238 - "Community 238"
-Cohesion: 1.0
-Nodes (1): Load a custom OmniASR CTC checkpoint using fairseq2's registered family.
-
-### Community 239 - "Community 239"
-Cohesion: 1.0
-Nodes (1): Yield fixed-size chunks from a sequence.
-
-### Community 240 - "Community 240"
-Cohesion: 1.0
-Nodes (1): Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con
-
-### Community 241 - "Community 241"
-Cohesion: 1.0
-Nodes (1): Compute simple WER summary from aligned prediction/reference lists.
+Cohesion: 0.05
+Nodes (41): Claim Discipline, code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh full), code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh smoke), code:bash (bsub < scripts/hpc/build_lm_corpus.sh), code:text (omniASR_CTC_1B_v2 + E6 recipe + short-utterance CoRal-style ), CoRal Alignment Execution Plan, Decision gate, Decision gate (+33 more)
 
 ### Community 242 - "Community 242"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
+Cohesion: 0.12
+Nodes (17): Write benchmark artifacts in a stable, inspectable format., write_benchmark_outputs(), Read UTF-8 text lines without trailing newlines., Construct a pyctcdecode decoder lazily., Read UTF-8 text lines without trailing newlines., Write UTF-8 text lines with trailing newlines., Compute simple WER/CER summaries from aligned prediction/reference lists., Compute simple WER/CER summaries from aligned prediction/reference lists. (+9 more)
 
-### Community 243 - "Community 243"
-Cohesion: 1.0
-Nodes (1): Compact statistics for an LM text build.
+### Community 267 - "Community 267"
+Cohesion: 0.05
+Nodes (41): 10A — 3B VRAM probe ✓ DONE, 10B — 3B full training (E6-3B) ✓ DONE (usual-totem-74, 2026-04-12), 10C — Immediate next step: evaluate 3B on test, then decide on 50k resume, 8A — Download & store trained model checkpoints, 8B — Comprehensive evaluation matrix ✓ DONE (2026-04-09), 9A — 300M LR extension (E8), 9B — 1B LR extension (E8-1B), Benchmarks to Beat (+33 more)
 
-### Community 244 - "Community 244"
-Cohesion: 1.0
-Nodes (1): Decoded hypothesis with reference metadata.
+### Community 268 - "Community 268"
+Cohesion: 0.05
+Nodes (40): All `#BSUB` options, Array range syntax, Checking queue and node availability, code:bash (bsub < job.sh), code:bash (#!/bin/sh), code:bash (#!/bin/sh), code:bash (#!/bin/sh), code:bash (#BSUB -n 32) (+32 more)
 
-### Community 245 - "Community 245"
-Cohesion: 1.0
-Nodes (1): Normalize transcript text for LM training without changing Danish orthography.
+### Community 269 - "Community 269"
+Cohesion: 0.14
+Nodes (40): _(), an(), Be(), Bn(), cn(), e(), Ei(), Gn() (+32 more)
 
-### Community 246 - "Community 246"
-Cohesion: 1.0
-Nodes (1): Parse fairseq2 split names such as ``test`` or ``test_coral_v3_read_aloud``.
+### Community 270 - "Community 270"
+Cohesion: 0.09
+Nodes (40): Aa(), d(), De(), Dn(), Ea(), El(), eu(), fo() (+32 more)
 
-### Community 247 - "Community 247"
-Cohesion: 1.0
-Nodes (1): Yield rows from fairseq2 parquet shards for the requested corpora/split.
+### Community 271 - "Community 271"
+Cohesion: 0.05
+Nodes (36): 1. Larger batches without serial accumulation, 2. No gradient checkpointing overhead, 3. Longer audio (omniASR), 4. Wall-clock speed, code:yaml (# configs/hardware/local.yaml), code:bash (# Print resolved config — no model loading, no data download), code:block11 (configs/), code:yaml (# configs/hardware/hpc.yaml) (+28 more)
 
-### Community 248 - "Community 248"
-Cohesion: 1.0
-Nodes (1): Build a deterministic LM text corpus from fairseq2 parquet transcripts.
+### Community 272 - "Community 272"
+Cohesion: 0.06
+Nodes (35): Activating your environment in job scripts, Auto-loading modules on login, Checking available CUDA and Python modules on the cluster, code:bash (module list                          # show currently loaded), code:bash (# Install uv (run once on login node):), code:bash (# Source conda, then activate:), code:bash (source /work3/$USER/danish_asr/venv/bin/activate), code:bash (/work3/$USER/danish_asr/conda/envs/danish_asr/bin/python tra) (+27 more)
 
-### Community 249 - "Community 249"
-Cohesion: 1.0
-Nodes (1): Write normalized LM text, one line per example.
+### Community 273 - "Community 273"
+Cohesion: 0.07
+Nodes (29): alwaysAllow, args, command, disabled, env, tools, ALLOW_DB_DELETION, CACHE_ENABLED (+21 more)
 
-### Community 250 - "Community 250"
-Cohesion: 1.0
-Nodes (1): Write corpus stats as pretty JSON.
+### Community 274 - "Community 274"
+Cohesion: 0.07
+Nodes (27): Audio Processing, code:bash (# Both formats (fairseq2 + universal)), code:bash (python -m workflows.dataprep.dataloader_example \), code:bash (uv run python -m danish_asr.preprocessing --subset all --tar), code:block3 (data/), code:yaml (use_preprocessed: true), code:python (import io), code:python ("""Convert CoRal-v3 HuggingFace dataset to omnilingual ASR P) (+19 more)
 
-### Community 251 - "Community 251"
-Cohesion: 1.0
-Nodes (1): Load a small YAML config file.
+### Community 275 - "Community 275"
+Cohesion: 0.07
+Nodes (26): Checkpoint Resume, Checkpoints & Storage, code:bash (export OUTPUT_DIR="/path/to/checkpoints"), code:bash (# Fresh start:), code:yaml (model:), code:yaml (model:), code:bash (# Login node only (not inside a bsub job)), code:yaml (max_audio_len: 960_000       # can handle 60s) (+18 more)
 
-### Community 252 - "Community 252"
-Cohesion: 1.0
-Nodes (1): Find a cached tokenizer model file using the asset card basename.
+### Community 276 - "Community 276"
+Cohesion: 0.11
+Nodes (17): CoRalDataModule, Lightning DataModule for CoRal Danish ASR dataset., Set the feature processor and optional tokenizer.          Must be called before, Load and prepare CoRal dataset splits., Load from preprocessed Parquet files., Load from HuggingFace (original on-the-fly resampling)., configure_logging(), ASR training pipeline with PyTorch Lightning. (+9 more)
 
-### Community 253 - "Community 253"
-Cohesion: 1.0
-Nodes (1): Load the OmniASR tokenizer, preferring an explicit or cached local model file.
+### Community 277 - "Community 277"
+Cohesion: 0.08
+Nodes (24): Challenges in Data Collection, Citation, code:bibtex (@dataset{coral2024,), code:python (from datasets import load_dataset), Collection Methodology, conversation, CoRal Dataset Reference, Data Fields (+16 more)
 
-### Community 254 - "Community 254"
-Cohesion: 1.0
-Nodes (1): Build pyctcdecode labels in the exact OmniASR logit order.
+### Community 278 - "Community 278"
+Cohesion: 0.08
+Nodes (24): Benchmark CLI, Benchmark Module, code:bash (bsub < scripts/hpc/build_lm_corpus.sh), code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh smoke), code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh full), code:bash (KENLM_BINARY=/work3/$USER/artifacts/lm/danish_lm_alexandra_p), code:bash (uv run python scripts/hpc/benchmark_coral_style.py \), code:text (scores.scores.cer_coral) (+16 more)
 
-### Community 255 - "Community 255"
-Cohesion: 1.0
-Nodes (1): Remove special-token text artifacts after beam decoding.
+### Community 279 - "Community 279"
+Cohesion: 0.08
+Nodes (24): code:bash (invoke utils.dtu-vpn   # Connect to DTU VPN via openconnect ), code:bash (# Upload), code:bash (ssh userid@login.hpc.dtu.dk), code:bash (cd ~/.ssh), code:bash (ssh s123456@transfer.gbar.dtu.dk mkdir -m 700 -p .ssh), code:bash (ssh -i ~/.ssh/gbar s123456@login.hpc.dtu.dk), code:block6 (Host gbar1), code:bash (puttygen -t ed25519 -o gbar-putty -O private) (+16 more)
 
-### Community 256 - "Community 256"
-Cohesion: 1.0
-Nodes (1): Load a custom OmniASR CTC checkpoint using fairseq2's registered family.
+### Community 280 - "Community 280"
+Cohesion: 0.15
+Nodes (25): ba(), bl(), c(), cr(), ct(), fn(), ga(), k() (+17 more)
 
-### Community 257 - "Community 257"
-Cohesion: 1.0
-Nodes (1): Create an OmniASR inference pipeline for CTC decoding.
+### Community 281 - "Community 281"
+Cohesion: 0.08
+Nodes (23): Additional Notes, Alternative: Batch Merge, CI Status, Conclusion, Dependabot PR Review & Merge Plan, Detailed PR Analysis, Executive Summary, Merge Strategy & Recommendations (+15 more)
 
-### Community 258 - "Community 258"
-Cohesion: 1.0
-Nodes (1): Yield fixed-size chunks from a sequence.
+### Community 282 - "Community 282"
+Cohesion: 0.11
+Nodes (14): collate_fn(), _pad_1d_tensors(), CoRal Danish ASR dataset and data module., Pad variable-length 1D tensors to uniform length.      Returns (stacked_tensor,, Custom collate function for variable-length audio., audio_lengths should record original (pre-pad) lengths., When all items are the same length, no padding should occur., Whisper input_features (fixed-size mel-specs) should be stacked. (+6 more)
 
-### Community 259 - "Community 259"
-Cohesion: 1.0
-Nodes (1): Read UTF-8 text lines without trailing newlines.
+### Community 283 - "Community 283"
+Cohesion: 0.08
+Nodes (23): code:bash (# Wav2Vec2 smoke (500 steps, ~10 min)), code:bash (# First submission — starts fresh (no checkpoints yet)), code:bash (WAV2VEC2_RUN_DIR=/work3/$USER/outputs/my_run RESUME_CKPT=lat), code:bash (bsub < scripts/hpc/baseline/08_train_whisper.sh), code:yaml (per_device_train_batch_size: 1    # was 2), code:bash (ls /work3/$USER/data/preprocessed/read_aloud/train/part-*.pa), code:bash (wandb login --verify), Configuration (+15 more)
 
-### Community 260 - "Community 260"
-Cohesion: 1.0
-Nodes (1): Write UTF-8 text lines with trailing newlines.
+### Community 284 - "Community 284"
+Cohesion: 0.08
+Nodes (23): 6A: Overall Performance, 6B: Demographic Fairness Analysis, 6C: Comparison with Existing Models, code:bash (getquota_work3.sh          # storagepool 6 must be under 350), code:yaml (regime:), code:yaml (max_audio_len: 480_000       # 30s), code:yaml (max_audio_len: 960_000       # 60s), Conversion field mapping (+15 more)
 
-### Community 261 - "Community 261"
-Cohesion: 1.0
-Nodes (1): Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con
+### Community 285 - "Community 285"
+Cohesion: 0.11
+Nodes (13): Add(), Chain(), Init(), Link(), Start(), Wait(), FreeAll(), More() (+5 more)
 
-### Community 262 - "Community 262"
-Cohesion: 1.0
-Nodes (1): Construct a pyctcdecode decoder lazily.
+### Community 286 - "Community 286"
+Cohesion: 0.11
+Nodes (17): _MetricParser, Stateful parser that tracks fairseq2's multi-line metric blocks., Parse a line, returning (metrics_dict, step) when a block is complete., Return accumulated metrics and reset state., Parse single-line fairseq2 metrics format (pipe-delimited)., Flush any remaining metrics at end of stream., clean_fairseq2_dir(), Tests for HPC run_training metric parsing. (+9 more)
 
-### Community 263 - "Community 263"
-Cohesion: 1.0
-Nodes (1): Compute simple WER summary from aligned prediction/reference lists.
+### Community 287 - "Community 287"
+Cohesion: 0.12
+Nodes (24): __Pyx_Coroutine_clear(), __Pyx_Coroutine_Close(), __Pyx_Coroutine_Close_Method(), __Pyx_Coroutine_CloseIter(), __Pyx_Coroutine_dealloc(), __Pyx_Coroutine_del(), __Pyx_Coroutine_ExceptionClear(), __Pyx_Coroutine_FinishDelegation() (+16 more)
 
-### Community 264 - "Community 264"
-Cohesion: 1.0
-Nodes (1): Split decode records into aligned prediction and reference lists.
+### Community 288 - "Community 288"
+Cohesion: 0.10
+Nodes (21): parse_valid_split(), Parse fairseq2 split names such as ``test`` or ``test_coral_v3_read_aloud``., Remove special-token text artifacts after beam decoding., Remove special-token text artifacts after beam decoding., strip_special_tokens(), main(), parse_args(), Build a KenLM 3-gram model from a prepared text corpus. (+13 more)
 
-### Community 265 - "Community 265"
-Cohesion: 1.0
-Nodes (1): Apply greedy CTC decoding to a single logit sequence.
+### Community 289 - "Community 289"
+Cohesion: 0.14
+Nodes (20): log_system_info(), Log hostname, user, Python version, CUDA_VISIBLE_DEVICES, LSB_JOBID, disk space., Configure loguru with console (INFO) and file (DEBUG) sinks.      Returns the pa, setup_logging(), main(), Step 2: Convert universal Parquet → fairseq2 Parquet format.  Reads preprocessed, main(), Step 1: Verify universal Parquet data integrity on HPC.  Enhanced version of pre (+12 more)
 
-### Community 266 - "Community 266"
-Cohesion: 1.0
-Nodes (1): Decode one CTC logit sequence with greedy or beam search.
+### Community 290 - "Community 290"
+Cohesion: 0.09
+Nodes (21): code:bash (invoke --list               # See all available tasks), code:bash (#BSUB -B                                   # Email at job st), code:bash (#!/bin/bash), code:bash (a100sh                      # shared A100 (quick dev)), Commands, Common failure → fix, Danish ASR — Claude Code Instructions, Dataset (+13 more)
+
+### Community 291 - "Community 291"
+Cohesion: 0.09
+Nodes (21): Citation, code:bash (# Clone and setup), code:bash (invoke data.download    # Download CoRal-v3 dataset (cached ), code:bash (# Convert CoRal-v3 to Parquet format (required by fairseq2)), code:bash (invoke quality.ruff    # Lint + format), code:block5 (danish_asr/), code:bibtex (@dataset{coral2024,), Danish ASR (+13 more)
+
+### Community 292 - "Community 292"
+Cohesion: 0.16
+Nodes (15): CrossPlatformIsNaN(), FilePiece(), FindDelimiterOrEOF(), FirstToken(), Initialize(), InitializeNoRead(), MMapShift(), NamePossiblyFind() (+7 more)
+
+### Community 293 - "Community 293"
+Cohesion: 0.09
+Nodes (21): code:bash (invoke --list               # See all available tasks), code:bash (#BSUB -B                                   # Email at job st), code:bash (#!/bin/bash), code:bash (a100sh                      # shared A100 (quick dev)), Commands, Common failure → fix, Danish ASR - Copilot Instructions — Claude Code Instructions, Dataset (+13 more)
+
+### Community 294 - "Community 294"
+Cohesion: 0.13
+Nodes (22): ao(), au(), cu(), Dt(), es(), Go(), Gr(), he() (+14 more)
+
+### Community 295 - "Community 295"
+Cohesion: 0.13
+Nodes (22): __Pyx_CppExn2PyErr(), __Pyx_GetException(), __pyx_pf_5kenlm_15FullScoreReturn_2__repr__(), __pyx_pf_5kenlm_15FullScoreReturn_4__reduce_cython__(), __pyx_pf_5kenlm_15FullScoreReturn_6__setstate_cython__(), __pyx_pf_5kenlm_5Model___init__(), __pyx_pf_5kenlm_5State_10__setstate_cython__(), __pyx_pf_5kenlm_5State_8__reduce_cython__() (+14 more)
+
+### Community 296 - "Community 296"
+Cohesion: 0.16
+Nodes (8): PreprocessedCoRalDataset, CoRal dataset from preprocessed Parquet (no on-the-fly resampling).      Reads u, Too many skipped samples should raise RuntimeError., Tests for PreprocessedCoRalDataset loading universal Parquet., Create a temporary directory with a universal Parquet file., Constructing without pyarrow re-raises ImportError with actionable install hints, Cache ensures read_row_group is called once per row-group, not per sample., TestPreprocessedCoRalDataset
+
+### Community 297 - "Community 297"
+Cohesion: 0.10
+Nodes (19): All Available Models, Architecture, code:block1 (Audio (16kHz) → wav2vec2 encoder → CTC projection → character), code:bash (uv sync --group omni   # installs omnilingual-asr + pyarrow), code:python (from omnilingual_asr.models.inference.pipeline import ASRInf), CTC models, CTC Models (fast inference, no LM needed), Finetuning Strategy Options (+11 more)
+
+### Community 298 - "Community 298"
+Cohesion: 0.11
+Nodes (18): 1. Hardware topology is compatible with a 2-GPU attempt, 2. The model family documentation already treats 7B as multi-GPU territory, 3. fairseq2 itself supports distributed data/model parallel concepts, 4. The current repo wrapper does not actually launch multi-rank training, 5. fairseq2 auto-cluster setup does not currently support LSF, 6. Existing successful training evidence is single-rank, 7B Feasibility Investigation, code:python (cmd = [) (+10 more)
+
+### Community 299 - "Community 299"
+Cohesion: 0.11
+Nodes (18): code:bash (getquota_zhome.sh), code:bash (getquota_work3.sh   # look at storagepool 6 "NVMEs added in ), code:yaml (regime:), code:bash (rm -rf /work3/$USER/wandb/cache/), code:bash (getquota_work3.sh), code:bash (# Upload a directory (resumable, progress bar)), code:block7 ($HOME/danish_asr/                    # Git repo, configs, sc), code:bash (# In scripts/hpc/*.sh — after #BSUB directives:) (+10 more)
+
+### Community 300 - "Community 300"
+Cohesion: 0.26
+Nodes (17): ExtractNonRolling(), HugeMalloc(), HugeRealloc(), MapOrThrow(), MapRead(), MapZeroedWrite(), ReplaceAndCopy(), reset() (+9 more)
+
+### Community 301 - "Community 301"
+Cohesion: 0.14
+Nodes (16): chunked(), decode_ctc_logits(), decode_logits_with_argmax(), Read UTF-8 text lines without trailing newlines., Yield fixed-size chunks from a sequence., Apply greedy CTC decoding to a single logit sequence., Apply greedy CTC decoding to a single logit sequence., Decode one CTC logit sequence with greedy or beam search. (+8 more)
+
+### Community 302 - "Community 302"
+Cohesion: 0.11
+Nodes (17): 10. HPC Shell Script Deduplication, 11. Fixed Script Permissions, 1. Dead Source Modules Removed, 2. Dead Task Modules Removed, 3. Dead HPC Scripts Removed, 4. Docker Infrastructure Removed, 5. Dead Test Removed, 6. Junk Files Removed (+9 more)
+
+### Community 303 - "Community 303"
+Cohesion: 0.12
+Nodes (8): ApplyBackoffs, DispatchContext, ExtensionsFirstIteration, IdentifyTuning, InstanceMatch, Instances(), JointOrderCallback, ReadUnigrams
+
+### Community 304 - "Community 304"
+Cohesion: 0.17
+Nodes (14): configure_project_cache_environment(), _get_env_path(), get_project_fairseq2_cache_dir(), get_project_hf_cache_dir(), get_project_root(), _normalize_fairseq2_cache_dir(), Shared utility functions., Return the repository root. (+6 more)
+
+### Community 305 - "Community 305"
+Cohesion: 0.12
+Nodes (16): Background, code:bash (bsub < scripts/hpc/legacy/06a_vram_probe_1b.sh), code:bash (# 3B on 80GB node — conservative batch), code:bash (source scripts/hpc/env.sh && setup_omniasr), Decision Criteria, Execution Order, Goal, How to Check Results (+8 more)
+
+### Community 306 - "Community 306"
+Cohesion: 0.15
+Nodes (17): a(), bs(), Bt(), fs(), gs(), hs(), ls(), ms() (+9 more)
+
+### Community 307 - "Community 307"
+Cohesion: 0.26
+Nodes (13): MonkeyPatch, fake_fairseq2_store(), FakeCard, FakeField, FakeStore, FakeUri, Path, str (+5 more)
+
+### Community 308 - "Community 308"
+Cohesion: 0.23
+Nodes (6): Write rows to a fairseq2-format Parquet file., Write rows to a universal-format Parquet file., write_fairseq2_parquet(), write_universal_parquet(), TestFairseq2Parquet, TestUniversalParquet
+
+### Community 309 - "Community 309"
+Cohesion: 0.14
+Nodes (16): __Pyx_CLineForTraceback(), __Pyx_ErrFetchInState(), __Pyx_ErrRestoreInState(), __Pyx_GetBuiltinName(), __Pyx__GetModuleGlobalName(), __Pyx_Import(), __Pyx_InitCachedBuiltins(), __Pyx_modinit_type_init_code() (+8 more)
+
+### Community 310 - "Community 310"
+Cohesion: 0.13
+Nodes (15): bacct — accounting summary, bhist — job history, bjobs (standard LSF), bkill, bpeek — live job output, bstat (DTU custom — preferred), code:bash (bstat                      # all your jobs, compact), code:bash (bjobs                      # all your jobs) (+7 more)
+
+### Community 311 - "Community 311"
+Cohesion: 0.16
+Nodes (7): Immediate, main(), ParallelTestRun(), PrefetchQueue, Size(), TestRun(), URandom
+
+### Community 312 - "Community 312"
+Cohesion: 0.24
+Nodes (12): main(), prepare_config(), Prepare a Fairseq2 eval config that opens a one-corpus parquet root.  Fairseq2's, Return a full summary TSV to filter for a subset config.      Existing subset co, _resolve_project_path(), _safe_symlink(), _source_summary_for_subset(), _write_filtered_summary() (+4 more)
+
+### Community 313 - "Community 313"
+Cohesion: 0.14
+Nodes (13): code:block1 (## PR Review: [PR title or branch name]), Constraints, Output Format, Review Philosophy, Review Procedure, Step 1: Understand the Change, Step 2: Diff Analysis, Step 3: Correctness & Logic (+5 more)
+
+### Community 314 - "Community 314"
+Cohesion: 0.20
+Nodes (13): convert_split(), main(), parse_args(), process_audio(), Unified preprocessing for CoRal-v3: fairseq2 + universal Parquet formats.  Resam, Resample to 16kHz and FLAC-encode once.      Returns:         (flac_bytes, audio, Convert one HF split, writing enabled target formats.      Returns stats dict wi, Write language distribution stats TSV with hours column derived from total_audio (+5 more)
+
+### Community 316 - "Community 316"
+Cohesion: 0.14
+Nodes (13): code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh full), code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh smoke), code:bash (bsub < scripts/hpc/build_lm_corpus.sh), code:bash (bsub < scripts/hpc/benchmark_coral_style_decoder_analysis.sh), Combined Test Results, CoRal-Style CER Benchmark, CTC Decoding Comparison, Evaluation Results (+5 more)
+
+### Community 317 - "Community 317"
+Cohesion: 0.22
+Nodes (12): convert_split(), Convert one split from universal → fairseq2 Parquet., _make_fake_hf_dataset(), parquet_dir(), Tests for unified CoRal-v3 preprocessing., Create a mock HF dataset., test_both_targets(), test_corrupt_sample_skipped() (+4 more)
+
+### Community 318 - "Community 318"
+Cohesion: 0.24
+Nodes (9): Closer, ConvertToSorted(), DiskFlush(), Init(), MergeSortedFiles(), PartialViewProxy, Rewind(), SortedFiles() (+1 more)
+
+### Community 319 - "Community 319"
+Cohesion: 0.23
+Nodes (4): _DuplicateColWarningFilter, Suppress repeated 'DataFrame columns are not unique' warnings from fairseq2., Decide whether to suppress *line* and optionally return a replacement., TestDuplicateColWarningFilter
+
+### Community 320 - "Community 320"
+Cohesion: 0.18
+Nodes (13): bi(), ce(), ec(), get(), le(), Lp(), nt(), oc() (+5 more)
+
+### Community 321 - "Community 321"
+Cohesion: 0.21
+Nodes (11): convert_split(), _get_text_normalize(), main(), normalize_text(), Convert CoRal-v3 HuggingFace dataset to omnilingual ASR Parquet format.  Reads C, Convert one HF split to Parquet part files.      Returns stats dict with num_sam, Write language distribution stats TSV with hours column derived from total_audio, Normalize text using omnilingual ASR text normalizer. (+3 more)
+
+### Community 322 - "Community 322"
+Cohesion: 0.21
+Nodes (9): Wav2Vec2 for CTC-based ASR with optional LoRA fine-tuning.      Uses HuggingFace, Wav2Vec2ASR, Tests for model module., Model registry should contain registered ASR models., build_model should raise ValueError for unknown model., Wav2Vec2 should size the CTC head from config instead of checkpoint defaults., test_build_model_unknown_raises(), test_model_registry_has_models() (+1 more)
+
+### Community 323 - "Community 323"
+Cohesion: 0.24
+Nodes (5): double_conversion(), Infinity(), IsDenormal(), NaN(), Single()
+
+### Community 324 - "Community 324"
+Cohesion: 0.18
+Nodes (5): Arc, Evaluate(), LowerBound(), Vertex, Current()
+
+### Community 325 - "Community 325"
+Cohesion: 0.20
+Nodes (7): BackoffManager, BackoffQueueEntry, EntryOwner, MaxOrder(), Normalize(), Recurse, Thread
+
+### Community 326 - "Community 326"
+Cohesion: 0.20
+Nodes (7): ReadNGrams(), Activate(), Add(), Finished(), Milestone(), Next(), ErsatzProgress()
+
+### Community 327 - "Community 327"
+Cohesion: 0.17
+Nodes (10): FAIRSEQ2_CACHE_DIR, HF_DATASETS_CACHE, HF_HOME, PATH, PYTORCH_CUDA_ALLOC_CONF, TMPDIR, WANDB_CACHE_DIR, WANDB_DATA_DIR (+2 more)
+
+### Community 328 - "Community 328"
+Cohesion: 0.23
+Nodes (10): check_prerequisites(), ensure_data_symlink(), _init_wandb(), _log_metrics_to_wandb(), main(), Training wrapper for omniASR on HPC.  Sets up environment, creates data symlink,, Create symlink: PROJECT_DIR/data → SCRATCH_DIR/data so fairseq2 relative paths r, Verify training prerequisites. (+2 more)
+
+### Community 329 - "Community 329"
+Cohesion: 0.18
+Nodes (10): Cluster entry points, code:bash (ssh <userid>@login.hpc.dtu.dk       # login node), code:bash (bsub < job.sh              # submit job), Contents, DTU HPC Documentation, Essential commands, GPU queues, Official links (+2 more)
+
+### Community 330 - "Community 330"
+Cohesion: 0.27
+Nodes (8): ConsumeNewline(), IsEntirelyWhiteSpace(), ReadARPACounts(), ReadBackoff(), ReadCount(), ReadNGramHeader(), LowerRestBuild(), LowerRestBuild<ProbingModel>
+
+### Community 331 - "Community 331"
+Cohesion: 0.38
+Nodes (9): parse_args(), Build a deterministic Danish KenLM text corpus., parse_args(), test_parse_args_accepts_beam_with_kenlm(), test_parse_args_beam_without_kenlm_is_allowed(), test_parse_args_defaults_to_greedy(), test_parse_args_rejects_alpha_with_greedy(), test_parse_args_rejects_beam_width_with_greedy() (+1 more)
+
+### Community 332 - "Community 332"
+Cohesion: 0.24
+Nodes (5): Write rows to a Parquet file with the required schema., write_parquet(), Tests for CoRal-v3 to Parquet conversion functions., TestWriteParquet, TestWriteStatsTsv
+
+### Community 333 - "Community 333"
+Cohesion: 0.22
+Nodes (10): build_pyctcdecode_labels(), _get_cached_tokenizer_path(), load_omniasr_tokenizer(), Find a cached tokenizer model file using the asset card basename., Load the OmniASR tokenizer, preferring an explicit or cached local model file., Load the OmniASR tokenizer, preferring an explicit or cached local model file., Build pyctcdecode labels in the exact OmniASR logit order., Build pyctcdecode labels in the exact OmniASR logit order. (+2 more)
+
+### Community 334 - "Community 334"
+Cohesion: 0.29
+Nodes (9): collate_decode_records(), DecodeResult, Split decode records into aligned prediction and reference lists., Split decode records into aligned prediction and reference lists., Decoded hypothesis with reference metadata., _decode_batch(), main(), Run standalone CTC decoding for OmniASR checkpoints with greedy or pyctcdecode b (+1 more)
+
+### Community 335 - "Community 335"
+Cohesion: 0.31
+Nodes (9): get_device(), Get the best available device. Priority: CUDA > MPS > CPU., _audio_to_tensor(), _decode_batch(), _default_report_label(), main(), parse_args(), Evaluate an OmniASR checkpoint with Alexandra/CoRal-style CER/WER. (+1 more)
+
+### Community 336 - "Community 336"
+Cohesion: 0.20
+Nodes (9): code:bash (graphify query "how does CTC LM decode connect to HPC evalua), code:bash (graphify path "CoRalDataset" "ASRLitModel"), code:bash (graphify explain "PreprocessedCoRalDataset"), code:bash (graphify update .), Graphify and Codex Usage, How Codex Should Use It, Keeping the Graph Fresh, Local Codex Integration (+1 more)
+
+### Community 337 - "Community 337"
+Cohesion: 0.25
+Nodes (8): build_model(), from_config(), ModelConfigFactory, ASR model definitions with LoRA fine-tuning support., Decorator to register a model class., Build a model from config., register_model(), Protocol
+
+### Community 338 - "Community 338"
+Cohesion: 0.22
+Nodes (9): code:bash (tensorboard --logdir=$OUTPUT_DIR/logs --port=6006 --host=$HO), code:bash (ssh -N -L 6006:COMPUTE_NODE_HOSTNAME:6006 USERNAME@login.hpc), code:bash (export WANDB_API_KEY=<your-key>), code:bash (export WANDB_MODE=offline), code:bash (ssh -N \), Forwarding multiple ports at once, TensorBoard, TensorBoard and W&B via SSH tunnel (+1 more)
+
+### Community 339 - "Community 339"
+Cohesion: 0.22
+Nodes (9): code:bash (# Quickest: shared A100 node), code:bash (module load cuda/11.7), code:block7 (http://gpunode042:40000/?token=401bb4a3a4faeafd2fd948a137b0f), code:bash (# Replace HOSTNAME with compute node name, USERNAME with you), Running Jupyter on a GPU node, Step 1: Get an interactive GPU session and note the hostname, Step 2: Start Jupyter on the compute node, Step 3: SSH tunnel from your local machine (+1 more)
+
+### Community 340 - "Community 340"
+Cohesion: 0.25
+Nodes (6): MergeWorker, ReunifyBackoff(), BOOST_AUTO_TEST_CASE(), CheckOutput, WriteBackoffs, WriteInput
+
+### Community 341 - "Community 341"
+Cohesion: 0.25
+Nodes (4): Backend, FullScore(), FullScoreForgotState(), Model()
+
+### Community 342 - "Community 342"
+Cohesion: 0.28
+Nodes (6): BOOST_AUTO_TEST_CASE(), BOOST_AUTO_TEST_CASE(), BOOST_AUTO_TEST_CASE(), FileLocation(), SeekOrThrow(), Read()
+
+### Community 343 - "Community 343"
+Cohesion: 0.25
+Nodes (3): Callback, OutputProbBackoff, OutputQ
+
+### Community 344 - "Community 344"
+Cohesion: 0.32
+Nodes (6): _build_overrides(), W&B sweep-compatible training entrypoint.  Maps sweep CLI flags into Hydra confi, Build Hydra config overrides from non-None CLI parameters., Train one run (designed to be launched by `wandb agent`)., _resolve_output_base(), sweep_train()
+
+### Community 345 - "Community 345"
+Cohesion: 0.25
+Nodes (7): Beam Search, code:text (score(W) = acoustic_score + alpha * lm_score + beta * word_c), code:text (P(next_word | previous_word_1, previous_word_2)), code:text (beam_width = 64), CTC Beam Search And KenLM Reference, KenLM, Methodology Implication
+
+### Community 346 - "Community 346"
+Cohesion: 0.25
+Nodes (7): Cluster status commands, code:bash (nodestat hpc               # all CPU nodes: status, cores us), code:python (import torch), code:python (# At start of training:), DTU HPC — Interactive Sessions, Monitoring, and Debugging, Full memory snapshot (flame graph), GPU memory profiling (PyTorch)
+
+### Community 347 - "Community 347"
+Cohesion: 0.25
+Nodes (8): code:bash (voltash    # 2× V100 PCIe, 16 GB each), code:bash (nvidia-smi), code:bash (linuxsh    # lands you on a shared CPU node, dynamically ass), code:bash (# 1 A100, 4 cores, 16 GB RAM, 1-hour session), Exclusive GPU via scheduler (bsub -Is), Generic interactive compute node (no GPU), Interactive nodes, Shared GPU nodes (always on, no scheduler)
+
+### Community 348 - "Community 348"
+Cohesion: 0.25
+Nodes (8): code:bash (bjobs -l <jobid>           # if job is still in the system), code:bash (# While running:), code:bash (# Get interactive session), Debugging failed jobs, Step 1: Check the termination reason, Step 2: Read the logs, Step 3: Common failures and fixes, Step 4: Interactive smoke test before batch submission
+
+### Community 349 - "Community 349"
+Cohesion: 0.32
+Nodes (5): BoundedSequenceEncoding(), MakeEncoder(), BOOST_AUTO_TEST_CASE(), CheckOutput(), WriteInput
+
+### Community 350 - "Community 350"
+Cohesion: 0.32
+Nodes (5): HandleNGrams(), HandleSuffix(), NGramHandler, NGramHandlers, Run()
+
+### Community 351 - "Community 351"
+Cohesion: 0.36
+Nodes (6): BOOST_AUTO_TEST_CASE(), DoNothingEnumerate, ParseVocab(), TestFiles, VocabEntry(), WriteVocabFile()
+
+### Community 352 - "Community 352"
+Cohesion: 0.25
+Nodes (7): CTC_KENLM_MANIFEST, DANISH_ASR_PROJECT_DIR, DECODERS, MAX_SAMPLES, OUTPUT_ROOT, OVERWRITE, ctc_kenlm_smoke_common.sh script
+
+### Community 353 - "Community 353"
+Cohesion: 0.29
+Nodes (8): bu_fn(), cs(), ip(), Pc(), Qs(), Rc(), v(), $()
+
+### Community 354 - "Community 354"
+Cohesion: 0.32
+Nodes (5): check_prerequisites() must sys.exit(1) when a Parquet file contains         in-f, check_prerequisites() must NOT sys.exit from the Parquet check when         file, Tests for the Parquet schema validation inside check_prerequisites()., Write a minimal Parquet file with the given column name→list mapping., TestCheckPrerequisitesParquetSchema
+
+### Community 355 - "Community 355"
+Cohesion: 0.29
+Nodes (6): 1. Collect the Previous Failure Logs, 2. Smoke CTC + Beam + KenLM, 3. Smoke LLM Zero-Shot Splits, code:bash (MAX_SAMPLES=2 DECODERS=greedy OVERWRITE=true bsub < scripts/), code:bash (EVAL_CONFIG=configs/fairseq2/llm_1b/llm-eval-base-1b.yaml bs), HPC Eval Validation Runbook
+
+### Community 356 - "Community 356"
+Cohesion: 0.29
+Nodes (7): Acceptance Criteria, Change, code:yaml (model:), Evaluation, HPC Notes, Priority 3 — Add A Short-Utterance Training Variant, Recommended First Config
+
+### Community 357 - "Community 357"
+Cohesion: 0.29
+Nodes (7): bnvtop (batch jobs only), code:bash (bnvtop <JOBID>), code:bash (nvidia-smi --query-gpu=index,timestamp,utilization.gpu,memory), code:bash (# Snapshot of all GPUs), GPU monitoring, Log GPU stats inside a batch job, nvidia-smi
+
+### Community 358 - "Community 358"
+Cohesion: 0.48
+Nodes (6): mkstemp_and_unlink(), BOOST_AUTO_TEST_CASE(), mkstemp(), ReadLoop(), TestRandom(), VerifyRead()
+
+### Community 360 - "Community 360"
+Cohesion: 0.33
+Nodes (6): Acceptance Criteria, Change, code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh full), code:bash (bash scripts/hpc/submit_coral_ctc_kenlm_eval.sh smoke), HPC Notes, Priority 0 — Lock The Direct Benchmark Before New Training
+
+### Community 361 - "Community 361"
+Cohesion: 0.33
+Nodes (6): Acceptance Criteria, Change, HPC Notes, Implementation Options, Priority 4 — Add A Moderate Audio Augmentation Ablation, Recommended First Experiment
+
+### Community 362 - "Community 362"
+Cohesion: 0.33
+Nodes (4): CompareFiles, MergeVocab(), Readers, VocabFileReader
+
+### Community 363 - "Community 363"
+Cohesion: 0.53
+Nodes (5): Pipeline(), SetupInputs(), SinkSort(), SourceSort(), Compare()
+
+### Community 364 - "Community 364"
+Cohesion: 0.40
+Nodes (4): _make_parquet_dir(), Tests for CoRal data pipeline., Test that PreprocessedCoRalDataset items work with collate_fn., TestPreprocessedCollateFn
+
+### Community 365 - "Community 365"
+Cohesion: 0.40
+Nodes (5): Acceptance Criteria, Change, HPC Notes, Priority 2 — Audit The Effective Read-Aloud / Conversation Sampling Ratio, Recommended Target
+
+### Community 366 - "Community 366"
+Cohesion: 0.40
+Nodes (5): Acceptance Criteria, Change, HPC Notes, Optional Future Experiment, Priority 5 — Align Text Normalization For Benchmarking, Not Necessarily Training
+
+### Community 367 - "Community 367"
+Cohesion: 0.40
+Nodes (4): code:text (omniASR_CTC_1B_v2 + E6 recipe + CoRal-style short utterance ), Current Best Guess, OmniASR CoRal Methodology Alignment Plan, Recommended Execution Order
+
+### Community 368 - "Community 368"
+Cohesion: 0.60
+Nodes (4): DANISH_ASR_PROJECT_DIR, has_decoder(), run_command(), benchmark_ctc_kenlm_my_method.sh script
+
+### Community 371 - "Community 371"
+Cohesion: 0.40
+Nodes (5): __pyx_pf_5kenlm_5Model_4path_2__set__(), __pyx_pf_5kenlm_5Model_4path_4__del__(), __pyx_pw_5kenlm_5Model_4path_3__set__(), __pyx_pw_5kenlm_5Model_4path_5__del__(), __pyx_setprop_5kenlm_5Model_path()
+
+### Community 372 - "Community 372"
+Cohesion: 0.50
+Nodes (3): Danish ASR, Documentation, Quick Reference
+
+### Community 373 - "Community 373"
+Cohesion: 0.50
+Nodes (4): Acceptance Criteria, Change, HPC Notes, Priority 7 — Separate LM / Beam Decoding From Model Training Comparisons
+
+### Community 374 - "Community 374"
+Cohesion: 0.50
+Nodes (4): Acceptance Criteria, Change, HPC Notes, Priority 8 — Add Fairness-Oriented Reporting To Every CoRal-Style Result
+
+### Community 375 - "Community 375"
+Cohesion: 0.50
+Nodes (4): Acceptance Criteria, Change, HPC Notes, Priority 1 — Match Alexandra's Evaluation Regime Exactly
+
+### Community 376 - "Community 376"
+Cohesion: 0.50
+Nodes (4): Change, Decision Rule, HPC Notes, Priority 6 — Revisit Step Budget After Short-Utterance Results
+
+### Community 377 - "Community 377"
+Cohesion: 0.67
+Nodes (3): DANISH_ASR_PROJECT_DIR, run_one(), benchmark_coral_style_alexandra_matrix.sh script
+
+### Community 378 - "Community 378"
+Cohesion: 0.67
+Nodes (3): DANISH_ASR_PROJECT_DIR, run_one(), benchmark_coral_style_decoder_analysis.sh script
+
+### Community 379 - "Community 379"
+Cohesion: 0.67
+Nodes (3): DANISH_ASR_PROJECT_DIR, run_one(), benchmark_coral_style_matrix.sh script
+
+### Community 380 - "Community 380"
+Cohesion: 0.50
+Nodes (3): DANISH_ASR_PROJECT_DIR, SMOKE_DECODERS, ctc_kenlm_smoke_beam_lm.sh script
+
+### Community 381 - "Community 381"
+Cohesion: 0.50
+Nodes (3): DANISH_ASR_PROJECT_DIR, SMOKE_DECODERS, ctc_kenlm_smoke_beam_no_lm.sh script
+
+### Community 382 - "Community 382"
+Cohesion: 0.50
+Nodes (3): DANISH_ASR_PROJECT_DIR, SMOKE_DECODERS, ctc_kenlm_smoke_greedy.sh script
+
+### Community 383 - "Community 383"
+Cohesion: 0.50
+Nodes (3): CTC_KENLM_MANIFEST, DANISH_ASR_PROJECT_DIR, submit_ctc_kenlm_eval.sh script
+
+### Community 386 - "Community 386"
+Cohesion: 0.50
+Nodes (4): __pyx_getprop_5kenlm_15FullScoreReturn_ngram_length(), __pyx_pf_5kenlm_15FullScoreReturn_12ngram_length___get__(), __pyx_pw_5kenlm_15FullScoreReturn_12ngram_length_1__get__(), __Pyx_PyInt_From_int()
+
+### Community 387 - "Community 387"
+Cohesion: 0.50
+Nodes (4): __pyx_getprop_5kenlm_5Model_order(), __pyx_pf_5kenlm_5Model_5order___get__(), __pyx_pw_5kenlm_5Model_5order_1__get__(), __Pyx_PyInt_From_unsigned_int()
+
+### Community 388 - "Community 388"
+Cohesion: 0.50
+Nodes (4): __pyx_getprop_5kenlm_6Config_arpa_complain(), __pyx_pf_5kenlm_6Config_13arpa_complain___get__(), __pyx_pw_5kenlm_6Config_13arpa_complain_1__get__(), __Pyx_PyInt_From_enum__lm_3a__3a_ngram_3a__3a_Config_3a__3a_ARPALoadComplain()
+
+### Community 389 - "Community 389"
+Cohesion: 0.50
+Nodes (4): __pyx_getprop_5kenlm_6Config_load_method(), __pyx_pf_5kenlm_6Config_11load_method___get__(), __pyx_pw_5kenlm_6Config_11load_method_1__get__(), __Pyx_PyInt_From_enum__util_3a__3a_LoadMethod()
+
+### Community 390 - "Community 390"
+Cohesion: 0.50
+Nodes (4): __pyx_pf_5kenlm_6Config_11load_method_2__set__(), __pyx_pw_5kenlm_6Config_11load_method_3__set__(), __Pyx_PyInt_As_enum__util_3a__3a_LoadMethod(), __pyx_setprop_5kenlm_6Config_load_method()
+
+### Community 403 - "Community 403"
+Cohesion: 0.67
+Nodes (3): __Pyx_CheckKeywordStrings(), __pyx_pf_5kenlm_6Config___init__(), __pyx_pw_5kenlm_6Config_1__init__()
+
+### Community 404 - "Community 404"
+Cohesion: 1.00
+Nodes (3): __Pyx_Coroutine_patch_module(), __Pyx_patch_abc(), __Pyx_patch_abc_module()
+
+### Community 405 - "Community 405"
+Cohesion: 0.67
+Nodes (3): __pyx_getprop_5kenlm_15FullScoreReturn_log_prob(), __pyx_pf_5kenlm_15FullScoreReturn_8log_prob___get__(), __pyx_pw_5kenlm_15FullScoreReturn_8log_prob_1__get__()
 
 ## Knowledge Gaps
-- **421 isolated node(s):** `Invoke tasks for Danish ASR.  Tasks are organized into namespaces for better org`, `Load a module from a file path.`, `CoRal Danish ASR dataset and data module.`, `CoRal Danish speech dataset wrapper.      Wraps HuggingFace datasets for CoRal r`, `CoRal dataset from preprocessed Parquet (no on-the-fly resampling).      Reads u` (+416 more)
+- **667 isolated node(s):** `command`, `args`, `DEFAULT_DATABASE`, `FALKORDB_PATH`, `FALKORDB_SOCKET_PATH` (+662 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 49`** (7 nodes): `exception.cc`, `ErrnoException()`, `Exception()`, `HandleStrerror()`, `OverflowException()`, `SetLocation()`, `WindowsException()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 59`** (5 nodes): `bit_packing.cc`, `bit_packing_test.cc`, `BitPackingSanity()`, `RequiredBits()`, `BOOST_AUTO_TEST_CASE()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 64`** (4 nodes): `setup.py`, `build_ext`, `.run()`, `compile_test()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 67`** (4 nodes): `parallel_read.cc`, `ParallelRead()`, `Reader`, `.Reader()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (4 nodes): `vocab.cc`, `IsLineEnd()`, `ReadMultiple()`, `ReadSingle()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 71`** (4 nodes): `PrintLead()`, `Run()`, `VocabReconstitute()`, `print.cc`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 72`** (4 nodes): `SizeNotify`, `.SizeNotify()`, `SizeOption()`, `size_option.cc`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 74`** (3 nodes): `Register danish_asr asset cards (datasets) with fairseq2.`, `setup_fairseq2_extension()`, `__init__.py`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 75`** (3 nodes): `test_llm_eval_configs.py`, `Regression test: LLM eval configs must have family+arch whenever path is set.  f`, `test_llm_eval_config_has_family_and_arch_when_path_is_set()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 76`** (3 nodes): `main()`, `upload_checkpoints.py`, `Upload finetuned model checkpoints to W&B as artifacts.  Run from project root (`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 77`** (3 nodes): `main()`, `Pre-download omniASR LLM V2 checkpoint + tokenizer to FAIRSEQ2_CACHE_DIR.  Run o`, `pull_llm_assets.py`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (3 nodes): `main()`, `Patch omnilingual-asr wer_calculator.py to handle empty CTC hypotheses.  Fixes k`, `patch_wer_calculator.py`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 79`** (3 nodes): `main()`, `Legacy helper to filter language_distribution_0.tsv to one CoRal-v3 subset.  Dep`, `make_subset_tsv.py`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 80`** (3 nodes): `multi_intersection_test.cc`, `BOOST_AUTO_TEST_CASE()`, `RangeFromArray()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 81`** (3 nodes): `cat_compressed_main.cc`, `Copy()`, `main()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 82`** (3 nodes): `probing_hash_table_test.cc`, `BOOST_AUTO_TEST_CASE()`, `Entry64()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 83`** (3 nodes): `sort_test.cc`, `BOOST_AUTO_TEST_CASE()`, `Putter()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (3 nodes): `BOOST_AUTO_TEST_CASE()`, `CheckAnswers`, `corpus_count_test.cc`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 88`** (3 nodes): `interpolate_main.cc`, `main()`, `MungeWeightArgs()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 89`** (2 nodes): `LM-related helper scripts.`, `__init__.py`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 116`** (1 nodes): `True once the first warning occurrence has been seen.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (1 nodes): `Create an OmniASR inference pipeline for CTC decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (1 nodes): `Read UTF-8 text lines without trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (1 nodes): `Construct a pyctcdecode decoder lazily.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (1 nodes): `Create an OmniASR inference pipeline for CTC decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (1 nodes): `Yield fixed-size chunks from a sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (1 nodes): `Construct a pyctcdecode decoder lazily.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (1 nodes): `Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (1 nodes): `Construct a pyctcdecode decoder lazily.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (1 nodes): `Compute simple WER/CER summaries from aligned prediction/reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (1 nodes): `Return preflight errors for the requested eval method.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (1 nodes): `Get the best available device. Priority: CUDA > MPS > CPU.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (1 nodes): `Build pyctcdecode labels in the exact OmniASR logit order.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (1 nodes): `Build pyctcdecode labels in the exact OmniASR logit order.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (1 nodes): `Load a custom OmniASR CTC checkpoint using fairseq2's registered family.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (1 nodes): `Read UTF-8 text lines without trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (1 nodes): `Yield fixed-size chunks from a sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (1 nodes): `Write UTF-8 text lines with trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (1 nodes): `Construct a pyctcdecode decoder lazily.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (1 nodes): `Compute simple WER/CER summaries from aligned prediction/reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (1 nodes): `Return a full summary TSV to filter for a subset config.      Existing subset co`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (1 nodes): `Pin model and dataset caches to the project drive.      This keeps large Hugging`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (1 nodes): `Get the best available device. Priority: CUDA > MPS > CPU.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (1 nodes): `Load the OmniASR tokenizer, preferring an explicit or cached local model file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (1 nodes): `Build pyctcdecode labels in the exact OmniASR logit order.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (1 nodes): `Create an OmniASR inference pipeline for CTC decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (1 nodes): `Create an OmniASR inference pipeline for CTC decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (1 nodes): `Yield fixed-size chunks from a sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (1 nodes): `Read UTF-8 text lines without trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (1 nodes): `Write UTF-8 text lines with trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (1 nodes): `Construct a pyctcdecode decoder lazily.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (1 nodes): `Return a full summary TSV to filter for a subset config.      Existing subset co`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (1 nodes): `Get the best available device. Priority: CUDA > MPS > CPU.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (1 nodes): `Build a de-duplicated text LM corpus from one or more Hugging Face text datasets`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (1 nodes): `Write normalized LM text, one line per example.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (1 nodes): `Write corpus stats as pretty JSON.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (1 nodes): `Load a small YAML config file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (1 nodes): `Find a cached tokenizer model file using the asset card basename.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (1 nodes): `Load the OmniASR tokenizer, preferring an explicit or cached local model file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (1 nodes): `Build pyctcdecode labels in the exact OmniASR logit order.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (1 nodes): `Load a custom OmniASR CTC checkpoint using fairseq2's registered family.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (1 nodes): `Yield fixed-size chunks from a sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (1 nodes): `Write UTF-8 text lines with trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (1 nodes): `Write UTF-8 text lines with trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (1 nodes): `Construct a pyctcdecode decoder lazily.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (1 nodes): `Compute simple WER summary from aligned prediction/reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (1 nodes): `Return preflight errors for the requested eval method.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (1 nodes): `Compact statistics for an LM text build.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (1 nodes): `Decoded hypothesis with reference metadata.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (1 nodes): `Normalize transcript text for LM training without changing Danish orthography.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (1 nodes): `Parse fairseq2 split names such as ``test`` or ``test_coral_v3_read_aloud``.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (1 nodes): `Yield rows from fairseq2 parquet shards for the requested corpora/split.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `Build a deterministic LM text corpus from fairseq2 parquet transcripts.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (1 nodes): `Build a de-duplicated text LM corpus from one or more Hugging Face text datasets`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (1 nodes): `Write normalized LM text, one line per example.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (1 nodes): `Write corpus stats as pretty JSON.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (1 nodes): `Find a cached tokenizer model file using the asset card basename.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (1 nodes): `Load the OmniASR tokenizer, preferring an explicit or cached local model file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (1 nodes): `Load a custom OmniASR CTC checkpoint using fairseq2's registered family.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (1 nodes): `Create an OmniASR inference pipeline for CTC decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (1 nodes): `Read UTF-8 text lines without trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (1 nodes): `Write UTF-8 text lines with trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (1 nodes): `Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (1 nodes): `Compute simple WER summary from aligned prediction/reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (1 nodes): `Build a de-duplicated text LM corpus from one or more Hugging Face text datasets`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (1 nodes): `Write normalized LM text, one line per example.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (1 nodes): `Write corpus stats as pretty JSON.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (1 nodes): `Load a small YAML config file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (1 nodes): `Build pyctcdecode labels in the exact OmniASR logit order.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (1 nodes): `Build pyctcdecode labels in the exact OmniASR logit order.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (1 nodes): `Write UTF-8 text lines with trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (1 nodes): `Create an OmniASR inference pipeline for CTC decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (1 nodes): `Yield fixed-size chunks from a sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (1 nodes): `Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (1 nodes): `Compute simple WER summary from aligned prediction/reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (1 nodes): `Resolve a dtype string with a CPU-safe fallback.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `Exclusion is enforced on normalized text, so casing / URLs / metadata don't bypa`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (1 nodes): `Build a de-duplicated text LM corpus from Hugging Face datasets.      This is in`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (1 nodes): `Write normalized LM text, one line per example.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (1 nodes): `Write corpus stats as pretty JSON.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (1 nodes): `Load a small YAML config file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (1 nodes): `Find a cached tokenizer model file using the asset card basename.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (1 nodes): `Load the OmniASR tokenizer, preferring an explicit or cached local model file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (1 nodes): `Load a custom OmniASR CTC checkpoint using fairseq2's registered family.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (1 nodes): `Yield fixed-size chunks from a sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (1 nodes): `Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (1 nodes): `Compute simple WER summary from aligned prediction/reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (1 nodes): `Compact statistics for an LM text build.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (1 nodes): `Decoded hypothesis with reference metadata.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (1 nodes): `Normalize transcript text for LM training without changing Danish orthography.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (1 nodes): `Parse fairseq2 split names such as ``test`` or ``test_coral_v3_read_aloud``.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (1 nodes): `Yield rows from fairseq2 parquet shards for the requested corpora/split.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (1 nodes): `Build a deterministic LM text corpus from fairseq2 parquet transcripts.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (1 nodes): `Write normalized LM text, one line per example.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (1 nodes): `Write corpus stats as pretty JSON.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (1 nodes): `Load a small YAML config file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (1 nodes): `Find a cached tokenizer model file using the asset card basename.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (1 nodes): `Load the OmniASR tokenizer, preferring an explicit or cached local model file.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (1 nodes): `Build pyctcdecode labels in the exact OmniASR logit order.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (1 nodes): `Remove special-token text artifacts after beam decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (1 nodes): `Load a custom OmniASR CTC checkpoint using fairseq2's registered family.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (1 nodes): `Create an OmniASR inference pipeline for CTC decoding.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (1 nodes): `Yield fixed-size chunks from a sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (1 nodes): `Read UTF-8 text lines without trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (1 nodes): `Write UTF-8 text lines with trailing newlines.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (1 nodes): `Resolve checkpoint, tokenizer, dataset root, and split metadata from an eval con`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (1 nodes): `Construct a pyctcdecode decoder lazily.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (1 nodes): `Compute simple WER summary from aligned prediction/reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (1 nodes): `Split decode records into aligned prediction and reference lists.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (1 nodes): `Apply greedy CTC decoding to a single logit sequence.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (1 nodes): `Decode one CTC logit sequence with greedy or beam search.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **220 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `set()` connect `Community 2` to `Community 4`, `Community 6`, `Community 9`, `Community 12`, `Community 17`?**
-  _High betweenness centrality (0.208) - this node is a cross-community bridge._
-- **Why does `_t()` connect `Community 9` to `Community 0`, `Community 2`?**
-  _High betweenness centrality (0.126) - this node is a cross-community bridge._
-- **Why does `F()` connect `Community 0` to `Community 9`, `Community 1`?**
-  _High betweenness centrality (0.092) - this node is a cross-community bridge._
-- **Are the 4 inferred relationships involving `F()` (e.g. with `Kt()` and `ee()`) actually correct?**
-  _`F()` has 4 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `CoRalDataModule` connect `Community 276` to `Community 3`, `Community 364`, `Community 304`, `Community 282`, `Community 315`?**
+  _High betweenness centrality (0.021) - this node is a cross-community bridge._
+- **Why does `PreprocessedCoRalDataset` connect `Community 296` to `Community 321`, `Community 3`, `Community 4`, `Community 6`, `Community 364`, `Community 276`, `Community 308`, `Community 282`, `Community 317`?**
+  _High betweenness centrality (0.018) - this node is a cross-community bridge._
+- **Why does `Any` connect `Community 2` to `Community 12`, `Community 301`, `Community 16`, `Community 17`, `Community 242`, `Community 20`, `Community 52`?**
+  _High betweenness centrality (0.014) - this node is a cross-community bridge._
 - **Are the 63 inferred relationships involving `PreprocessedCoRalDataset` (e.g. with `TestCoRalDataset` and `TestCollateFn`) actually correct?**
   _`PreprocessedCoRalDataset` has 63 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 2 inferred relationships involving `F()` (e.g. with `Kt()` and `ee()`) actually correct?**
+  _`F()` has 2 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 12 inferred relationships involving `e()` (e.g. with `H()` and `$()`) actually correct?**
   _`e()` has 12 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 2 inferred relationships involving `t()` (e.g. with `I()` and `forEach()`) actually correct?**

--- a/scripts/hpc/resolve_fairseq2_asset_path.py
+++ b/scripts/hpc/resolve_fairseq2_asset_path.py
@@ -50,9 +50,11 @@ def resolve_cached_asset_uri(uri: str, cache_dir: str | Path) -> Path | None:
     """Resolve a cached fairseq2 asset URI without triggering a download."""
     normalised_uri, params = _normalise_uri(uri)
     if normalised_uri.startswith("file://"):
-        parsed_uri = urlparse(normalised_uri)
-        uri_path = f"//{parsed_uri.netloc}{parsed_uri.path}" if parsed_uri.netloc else parsed_uri.path
-        return Path(url2pathname(uri_path))
+        parsed = urlparse(normalised_uri)
+        path = parsed.path
+        if parsed.netloc and parsed.netloc != "localhost":
+            path = f"//{parsed.netloc}{path}"
+        return Path(url2pathname(path))
 
     asset_dir = cache_dir_for_uri(normalised_uri, cache_dir)
     if not asset_dir.exists():

--- a/src/danish_asr/lm.py
+++ b/src/danish_asr/lm.py
@@ -486,6 +486,7 @@ def _get_cached_tokenizer_path(tokenizer_name: str) -> Path | None:
         ]
     )
 
+    existing_roots: list[Path] = []
     seen_roots: set[Path] = set()
     for root in candidate_roots:
         if root in seen_roots:
@@ -493,20 +494,24 @@ def _get_cached_tokenizer_path(tokenizer_name: str) -> Path | None:
         seen_roots.add(root)
         if not root.exists():
             continue
+        existing_roots.append(root)
 
-        direct_match = root / model_name
-        if direct_match.is_file():
-            return direct_match
+    known_layout_candidates: list[Path] = []
+    for root in existing_roots:
+        known_layout_candidates.append(root / model_name)
+        known_layout_candidates.extend(sorted(root.glob(f"*/{model_name}")))
+        known_layout_candidates.extend(sorted(root.glob(f"assets/*/{model_name}")))
 
-        for match in sorted(root.glob(f"*/{model_name}")):
-            if match.is_file():
-                return match
+    seen_candidates: set[Path] = set()
+    for candidate in known_layout_candidates:
+        if candidate in seen_candidates:
+            continue
+        seen_candidates.add(candidate)
+        if candidate.is_file():
+            return candidate
 
-        for match in sorted(root.glob(f"assets/*/{model_name}")):
-            if match.is_file():
-                return match
-
-        matches = sorted(root.rglob(model_name))
+    for root in existing_roots:
+        matches = sorted(path for path in root.rglob(model_name) if path.is_file())
         if matches:
             return matches[0]
 

--- a/tests/test_resolve_fairseq2_asset_path.py
+++ b/tests/test_resolve_fairseq2_asset_path.py
@@ -34,3 +34,11 @@ def test_resolve_cached_asset_uri_accepts_file_uri(tmp_path: Path) -> None:
     model_path.write_bytes(b"model")
 
     assert resolve_cached_asset_uri(model_path.as_uri(), tmp_path) == model_path
+
+
+def test_resolve_cached_asset_uri_accepts_localhost_file_uri(tmp_path: Path) -> None:
+    model_path = tmp_path / "model with spaces.pt"
+    model_path.write_bytes(b"model")
+    uri = model_path.as_uri().replace("file://", "file://localhost", 1)
+
+    assert resolve_cached_asset_uri(uri, tmp_path) == model_path

--- a/tests/test_tokenizer_cache.py
+++ b/tests/test_tokenizer_cache.py
@@ -48,6 +48,24 @@ def test_get_cached_tokenizer_path_uses_active_fairseq2_cache(
     assert lm._get_cached_tokenizer_path("omniASR_tokenizer_written_v2") == tokenizer_path
 
 
+def test_get_cached_tokenizer_path_prefers_known_layout_without_recursive_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_fairseq2_store: None
+) -> None:
+    import danish_asr.lm as lm
+
+    tokenizer_path = tmp_path / "fairseq2_cache" / "abc123" / "omniasr_tokenizer.model"
+    tokenizer_path.parent.mkdir(parents=True)
+    tokenizer_path.write_text("tokenizer", encoding="utf-8")
+
+    def fail_rglob(self: Path, pattern: str) -> None:
+        raise AssertionError(f"unexpected recursive scan of {self} for {pattern}")
+
+    monkeypatch.setenv("FAIRSEQ2_CACHE_DIR", str(tmp_path / "fairseq2_cache"))
+    monkeypatch.setattr(Path, "rglob", fail_rglob)
+
+    assert lm._get_cached_tokenizer_path("omniASR_tokenizer_written_v2") == tokenizer_path
+
+
 def test_get_cached_tokenizer_path_accepts_assets_dir_env(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_fairseq2_store: None
 ) -> None:


### PR DESCRIPTION
## Summary
- handle `file://localhost/...` cached fairseq2 asset URIs as local paths
- prefer known fairseq2 tokenizer cache layouts before falling back to recursive scans
- refresh the graphify report after the code changes

## Why
The CTC + Beam + KenLM HPC flow depends on resolving cached tokenizer and asset paths reliably. These changes make tokenizer lookup faster and more predictable, and avoid treating localhost file URIs as UNC-style paths.

## Validation
- pre-commit hooks during commit: ruff, ruff format, bandit, codespell, mypy, and standard file checks
- `uv run pytest tests/test_resolve_fairseq2_asset_path.py tests/test_tokenizer_cache.py`